### PR TITLE
Add checksum verification for completed downloads

### DIFF
--- a/Harbor/Models/AddDownloadRequest.swift
+++ b/Harbor/Models/AddDownloadRequest.swift
@@ -4,6 +4,7 @@ struct AddDownloadRequest: Sendable {
     let sourceKind: DownloadSourceKind
     let sourceURL: URL
     let customFilename: String?
+    let expectedSHA256: String?
     let destinationFolder: URL
     let shouldStartImmediately: Bool
 }

--- a/Harbor/Models/AddDownloadSheetDraft.swift
+++ b/Harbor/Models/AddDownloadSheetDraft.swift
@@ -21,6 +21,7 @@ struct AddDownloadSheetDraft: Identifiable, Sendable {
     let entryMode: AddDownloadEntryMode
     let sourceURLText: String
     let customFilename: String
+    let expectedSHA256: String
     let torrentFileURL: URL?
     let destinationFolderURL: URL
     let shouldStartImmediately: Bool
@@ -30,6 +31,7 @@ struct AddDownloadSheetDraft: Identifiable, Sendable {
         entryMode: AddDownloadEntryMode,
         sourceURLText: String = "",
         customFilename: String = "",
+        expectedSHA256: String = "",
         torrentFileURL: URL? = nil,
         destinationFolderURL: URL,
         shouldStartImmediately: Bool
@@ -38,6 +40,7 @@ struct AddDownloadSheetDraft: Identifiable, Sendable {
         self.entryMode = entryMode
         self.sourceURLText = sourceURLText
         self.customFilename = customFilename
+        self.expectedSHA256 = expectedSHA256
         self.torrentFileURL = torrentFileURL
         self.destinationFolderURL = destinationFolderURL
         self.shouldStartImmediately = shouldStartImmediately

--- a/Harbor/Models/DownloadItem.swift
+++ b/Harbor/Models/DownloadItem.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Observation
 
@@ -67,6 +68,11 @@ enum DownloadStatus: String, Codable, CaseIterable, Sendable {
     }
 }
 
+enum DownloadChecksumVerificationState: Sendable {
+    case verified
+    case failed
+}
+
 enum DownloadActivityKind: String, Codable, Sendable {
     case added
     case queued
@@ -115,6 +121,8 @@ struct DownloadRecord: Codable, Sendable {
     let resumeData: Data?
     let backendIdentifier: String?
     let metadataName: String?
+    let expectedSHA256: String?
+    let computedSHA256: String?
     let activityEvents: [DownloadActivityEvent]
 
     private enum CodingKeys: String, CodingKey {
@@ -137,6 +145,8 @@ struct DownloadRecord: Codable, Sendable {
         case resumeData
         case backendIdentifier
         case metadataName
+        case expectedSHA256
+        case computedSHA256
         case activityEvents
     }
 
@@ -160,6 +170,8 @@ struct DownloadRecord: Codable, Sendable {
         resumeData: Data?,
         backendIdentifier: String?,
         metadataName: String?,
+        expectedSHA256: String? = nil,
+        computedSHA256: String? = nil,
         activityEvents: [DownloadActivityEvent] = []
     ) {
         self.id = id
@@ -181,6 +193,8 @@ struct DownloadRecord: Codable, Sendable {
         self.resumeData = resumeData
         self.backendIdentifier = backendIdentifier
         self.metadataName = metadataName
+        self.expectedSHA256 = expectedSHA256
+        self.computedSHA256 = computedSHA256
         self.activityEvents = activityEvents
     }
 
@@ -205,6 +219,8 @@ struct DownloadRecord: Codable, Sendable {
         self.resumeData = try container.decodeIfPresent(Data.self, forKey: .resumeData)
         self.backendIdentifier = try container.decodeIfPresent(String.self, forKey: .backendIdentifier)
         self.metadataName = try container.decodeIfPresent(String.self, forKey: .metadataName)
+        self.expectedSHA256 = try container.decodeIfPresent(String.self, forKey: .expectedSHA256)
+        self.computedSHA256 = try container.decodeIfPresent(String.self, forKey: .computedSHA256)
         self.activityEvents = try container.decodeIfPresent([DownloadActivityEvent].self, forKey: .activityEvents) ?? []
     }
 
@@ -229,6 +245,8 @@ struct DownloadRecord: Codable, Sendable {
         try container.encode(resumeData, forKey: .resumeData)
         try container.encode(backendIdentifier, forKey: .backendIdentifier)
         try container.encode(metadataName, forKey: .metadataName)
+        try container.encode(expectedSHA256, forKey: .expectedSHA256)
+        try container.encode(computedSHA256, forKey: .computedSHA256)
         try container.encode(activityEvents, forKey: .activityEvents)
     }
 }
@@ -258,6 +276,8 @@ final class DownloadItem: Identifiable {
     var taskIdentifier: Int?
     var backendIdentifier: String?
     var metadataName: String?
+    var expectedSHA256: String?
+    var computedSHA256: String?
     var activityEvents: [DownloadActivityEvent]
 
     init(
@@ -283,6 +303,8 @@ final class DownloadItem: Identifiable {
         taskIdentifier: Int? = nil,
         backendIdentifier: String? = nil,
         metadataName: String? = nil,
+        expectedSHA256: String? = nil,
+        computedSHA256: String? = nil,
         activityEvents: [DownloadActivityEvent] = []
     ) {
         self.id = id
@@ -307,6 +329,8 @@ final class DownloadItem: Identifiable {
         self.taskIdentifier = taskIdentifier
         self.backendIdentifier = backendIdentifier
         self.metadataName = metadataName
+        self.expectedSHA256 = expectedSHA256
+        self.computedSHA256 = computedSHA256
         self.activityEvents = activityEvents
 
         if self.activityEvents.contains(where: { $0.kind == .added }) == false {
@@ -341,6 +365,8 @@ final class DownloadItem: Identifiable {
             taskIdentifier: nil,
             backendIdentifier: record.backendIdentifier,
             metadataName: record.metadataName,
+            expectedSHA256: record.expectedSHA256,
+            computedSHA256: record.computedSHA256,
             activityEvents: record.activityEvents
         )
     }
@@ -465,6 +491,16 @@ final class DownloadItem: Identifiable {
         lastError.map { Self.displayErrorMessage(from: $0) }
     }
 
+    var checksumVerificationState: DownloadChecksumVerificationState? {
+        guard status == .completed,
+              let expectedSHA256,
+              let computedSHA256 else {
+            return nil
+        }
+
+        return expectedSHA256 == computedSHA256 ? .verified : .failed
+    }
+
     var isRunning: Bool {
         status.isRunning
     }
@@ -498,6 +534,8 @@ final class DownloadItem: Identifiable {
             resumeData: resumeData,
             backendIdentifier: backendIdentifier,
             metadataName: metadataName,
+            expectedSHA256: expectedSHA256,
+            computedSHA256: computedSHA256,
             activityEvents: activityEvents
         )
     }
@@ -565,5 +603,43 @@ final class DownloadItem: Identifiable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         return path.isEmpty ? nil : path
+    }
+}
+
+enum SHA256Checksum {
+    static func normalized(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count == 64 else {
+            return nil
+        }
+
+        let hexCharacters = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        guard trimmed.unicodeScalars.allSatisfy({ hexCharacters.contains($0) }) else {
+            return nil
+        }
+
+        return trimmed.lowercased()
+    }
+
+    static func hashFile(at url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer {
+            try? handle.close()
+        }
+
+        // TODO: Add more checksum algorithms only when SHA-256 is not enough for real downloads.
+        var hasher = SHA256()
+        while true {
+            let data = try handle.read(upToCount: 1024 * 1024) ?? Data()
+            guard data.isEmpty == false else {
+                break
+            }
+
+            hasher.update(data: data)
+        }
+
+        return hasher.finalize()
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 }

--- a/Harbor/ViewModels/DownloadCenter.swift
+++ b/Harbor/ViewModels/DownloadCenter.swift
@@ -299,7 +299,8 @@ final class DownloadCenter {
             backend: backend,
             preferredFilename: preferredFilename,
             destinationFolderPath: request.destinationFolder.path,
-            status: request.shouldStartImmediately ? .queued : .paused
+            status: request.shouldStartImmediately ? .queued : .paused,
+            expectedSHA256: request.sourceKind == .directURL ? request.expectedSHA256 : nil
         )
 
         if request.sourceKind == .magnetLink {
@@ -356,6 +357,7 @@ final class DownloadCenter {
 
         item.lastError = nil
         item.finishedAt = nil
+        item.computedSHA256 = nil
         item.speedBytesPerSecond = 0
         item.uploadBytesPerSecond = 0
         item.updatedAt = .now
@@ -600,6 +602,7 @@ final class DownloadCenter {
 
         item.lastError = nil
         item.finishedAt = nil
+        item.computedSHA256 = nil
         item.speedBytesPerSecond = 0
         item.updatedAt = .now
 
@@ -1112,6 +1115,7 @@ final class DownloadCenter {
 
         item.fileLocationPath = destinationURL.path
         item.preferredFilename = destinationURL.lastPathComponent
+        item.computedSHA256 = item.expectedSHA256 == nil ? nil : try SHA256Checksum.hashFile(at: destinationURL)
         item.progress = 1
         item.expectedBytes = max(expectedBytes, item.bytesWritten)
         item.bytesWritten = max(item.bytesWritten, item.expectedBytes)
@@ -1336,19 +1340,35 @@ final class DownloadCenter {
 
         switch status {
         case .completed:
-            title = String(
-                localized: "notification.downloadFinished.title",
-                defaultValue: "Download Finished",
-                comment: "Notification title for a completed download."
-            )
-            body = String(
-                format: String(
-                    localized: "notification.downloadFinished.body",
-                    defaultValue: "%@ is ready.",
-                    comment: "Notification body for a completed download. Parameter is the download name."
-                ),
-                item.displayName
-            )
+            if item.checksumVerificationState == .failed {
+                title = String(
+                    localized: "notification.checksumFailed.title",
+                    defaultValue: "Checksum Failed",
+                    comment: "Notification title for a completed download whose checksum did not match."
+                )
+                body = String(
+                    format: String(
+                        localized: "notification.checksumFailed.body",
+                        defaultValue: "%@ finished but did not match its SHA-256 checksum.",
+                        comment: "Notification body for a completed download whose checksum did not match. Parameter is the download name."
+                    ),
+                    item.displayName
+                )
+            } else {
+                title = String(
+                    localized: "notification.downloadFinished.title",
+                    defaultValue: "Download Finished",
+                    comment: "Notification title for a completed download."
+                )
+                body = String(
+                    format: String(
+                        localized: "notification.downloadFinished.body",
+                        defaultValue: "%@ is ready.",
+                        comment: "Notification body for a completed download. Parameter is the download name."
+                    ),
+                    item.displayName
+                )
+            }
         case .failed:
             title = String(
                 localized: "notification.downloadFailed.title",

--- a/Harbor/Views/AddDownloadSheet.swift
+++ b/Harbor/Views/AddDownloadSheet.swift
@@ -5,6 +5,7 @@ struct AddDownloadSheet: View {
     private enum Field: Hashable {
         case sourceURL
         case filename
+        case checksum
     }
 
     let settings: AppSettingsStore
@@ -16,6 +17,7 @@ struct AddDownloadSheet: View {
     @State private var entryMode: AddDownloadEntryMode
     @State private var sourceURLText: String
     @State private var customFilename: String
+    @State private var expectedSHA256: String
     @State private var torrentFileURL: URL?
     @State private var destinationPath: String
     @State private var shouldStartImmediately: Bool
@@ -31,6 +33,7 @@ struct AddDownloadSheet: View {
         _entryMode = State(initialValue: draft.entryMode)
         _sourceURLText = State(initialValue: draft.sourceURLText)
         _customFilename = State(initialValue: draft.customFilename)
+        _expectedSHA256 = State(initialValue: draft.expectedSHA256)
         _torrentFileURL = State(initialValue: draft.torrentFileURL)
         _destinationPath = State(initialValue: draft.destinationFolderURL.path)
         _shouldStartImmediately = State(initialValue: draft.shouldStartImmediately)
@@ -59,6 +62,10 @@ struct AddDownloadSheet: View {
 
                     TextField("Optional file name override", text: $customFilename)
                         .focused($focusedField, equals: Field.filename)
+
+                    TextField("Optional SHA-256 checksum", text: $expectedSHA256)
+                        .font(.system(.body, design: .monospaced))
+                        .focused($focusedField, equals: Field.checksum)
                 } else {
                     LabeledContent("Torrent File") {
                         HStack(spacing: 8) {
@@ -176,6 +183,7 @@ struct AddDownloadSheet: View {
 
         let sourceURL: URL
         let sourceKind: DownloadSourceKind
+        var normalizedExpectedSHA256: String?
 
         switch entryMode {
         case .linkOrMagnet:
@@ -194,6 +202,31 @@ struct AddDownloadSheet: View {
 
             sourceURL = parsedURL
             sourceKind = detectedKind
+
+            let trimmedChecksum = expectedSHA256.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedChecksum.isEmpty == false {
+                guard detectedKind == .directURL else {
+                    validationMessage = String(
+                        localized: "add.validation.checksum.directOnly",
+                        defaultValue: "Checksum verification is available for direct downloads only.",
+                        comment: "Validation message shown when a checksum is entered for a non-direct download."
+                    )
+                    focusedField = .checksum
+                    return
+                }
+
+                guard let normalizedChecksum = SHA256Checksum.normalized(trimmedChecksum) else {
+                    validationMessage = String(
+                        localized: "add.validation.checksum.sha256",
+                        defaultValue: "Enter a 64-character SHA-256 checksum.",
+                        comment: "Validation message shown when the entered checksum is not a SHA-256 hex digest."
+                    )
+                    focusedField = .checksum
+                    return
+                }
+
+                normalizedExpectedSHA256 = normalizedChecksum
+            }
 
         case .torrentFile:
             guard let torrentFileURL,
@@ -218,6 +251,7 @@ struct AddDownloadSheet: View {
                 sourceKind: sourceKind,
                 sourceURL: sourceURL,
                 customFilename: sourceKind.supportsCustomFilename && trimmedFilename.isEmpty == false ? trimmedFilename : nil,
+                expectedSHA256: sourceKind == .directURL ? normalizedExpectedSHA256 : nil,
                 destinationFolder: folderURL,
                 shouldStartImmediately: shouldStartImmediately
             )

--- a/Harbor/Views/Components/DownloadStatusBadge.swift
+++ b/Harbor/Views/Components/DownloadStatusBadge.swift
@@ -2,30 +2,70 @@ import SwiftUI
 
 struct DownloadStatusBadge: View {
     let status: DownloadStatus
+    let checksumState: DownloadChecksumVerificationState?
 
     private var tint: Color {
+        switch checksumState {
+        case .verified:
+            return .green
+        case .failed:
+            return .red
+        case nil:
+            break
+        }
+
         switch status {
         case .queued:
-            .secondary
+            return .secondary
         case .preparing:
-            .orange
+            return .orange
         case .downloading:
-            .blue
+            return .blue
         case .browserSessionRequired:
-            .mint
+            return .mint
         case .paused:
-            .yellow
+            return .yellow
         case .completed:
-            .green
+            return .green
         case .failed:
-            .red
+            return .red
         case .cancelled:
-            .secondary
+            return .secondary
         }
     }
 
+    private var title: LocalizedStringResource {
+        switch checksumState {
+        case .verified:
+            LocalizedStringResource("checksum.verified", defaultValue: "Verified")
+        case .failed:
+            LocalizedStringResource("checksum.failed", defaultValue: "Checksum failed")
+        case nil:
+            status.title
+        }
+    }
+
+    private var systemImage: String {
+        switch checksumState {
+        case .verified:
+            "checkmark.shield.fill"
+        case .failed:
+            "xmark.shield.fill"
+        case nil:
+            status.systemImage
+        }
+    }
+
+    init(
+        status: DownloadStatus,
+        checksumState: DownloadChecksumVerificationState? = nil
+    ) {
+        self.status = status
+        self.checksumState = checksumState
+    }
+
     var body: some View {
-        Label(status.title, systemImage: status.systemImage)
+        Label(title, systemImage: systemImage)
             .font(.caption.weight(.semibold))
             .foregroundStyle(tint)
             .padding(.horizontal, 10)

--- a/Harbor/Views/DownloadDetailView.swift
+++ b/Harbor/Views/DownloadDetailView.swift
@@ -35,6 +35,9 @@ private struct DownloadInspectorContent: View {
 
                 DownloadTransferSection(item: item)
                 DownloadStorageSection(item: item)
+                if item.expectedSHA256 != nil {
+                    DownloadChecksumSection(item: item)
+                }
                 DownloadActivitySection(item: item)
 
                 if item.status == .browserSessionRequired {
@@ -128,7 +131,10 @@ private struct DownloadHeader: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                DownloadStatusBadge(status: item.status)
+                DownloadStatusBadge(
+                    status: item.status,
+                    checksumState: item.checksumVerificationState
+                )
             }
 
             progressBlock
@@ -441,6 +447,25 @@ private struct DownloadStorageSection: View {
                 if let fileLocationPath = item.fileLocationPath {
                     Divider()
                     DownloadValueRow(title: "Saved File", value: fileLocationPath)
+                }
+            }
+        }
+    }
+}
+
+private struct DownloadChecksumSection: View {
+    let item: DownloadItem
+
+    var body: some View {
+        DownloadDetailSection(title: "Checksum") {
+            VStack(spacing: 0) {
+                if let expectedSHA256 = item.expectedSHA256 {
+                    DownloadValueRow(title: "Expected SHA-256", value: expectedSHA256)
+                }
+
+                if let computedSHA256 = item.computedSHA256 {
+                    Divider()
+                    DownloadValueRow(title: "Computed SHA-256", value: computedSHA256)
                 }
             }
         }

--- a/Harbor/Views/DownloadsContentView.swift
+++ b/Harbor/Views/DownloadsContentView.swift
@@ -26,7 +26,10 @@ struct DownloadsContentView: View {
                     .disabledCustomizationBehavior(.visibility)
 
                     TableColumn("Status") { item in
-                        DownloadStatusBadge(status: item.status)
+                        DownloadStatusBadge(
+                            status: item.status,
+                            checksumState: item.checksumVerificationState
+                        )
                     }
                     .customizationID("status")
                     .defaultVisibility(.visible)

--- a/Harbor/Views/HarborPreviewFixtures.swift
+++ b/Harbor/Views/HarborPreviewFixtures.swift
@@ -64,7 +64,9 @@ enum HarborPreviewFixtures {
             speedBytesPerSecond: 0,
             startedAt: now.addingTimeInterval(-7_100),
             finishedAt: now.addingTimeInterval(-6_900),
-            updatedAt: now.addingTimeInterval(-6_900)
+            updatedAt: now.addingTimeInterval(-6_900),
+            expectedSHA256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            computedSHA256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         )
 
         let magnet = DownloadItem(


### PR DESCRIPTION
## Summary
- Add optional SHA-256 input for direct downloads.
- Persist expected and computed checksums for completed downloads.
- Show Verified or Checksum failed in list/detail UI without moving mismatches out of Completed.

## Validation
- `xcodebuild -project Harbor.xcodeproj -scheme Harbor -configuration Debug build`
- `git diff --check`

Closes #17