### PR TITLE
Expose torrent trackers in detail inspector

### DIFF
--- a/Harbor/Models/DownloadItem.swift
+++ b/Harbor/Models/DownloadItem.swift
@@ -511,6 +511,13 @@ final class DownloadItem: Identifiable {
             displayedTrackers.append(tracker)
         }
 
+        if sourceKind == .magnetLink {
+            for trackerURL in MagnetLinkMetadata(url: sourceURL).trackerURLs
+                where trackerURLs.insert(trackerURL).inserted {
+                displayedTrackers.append(TorrentTracker(url: trackerURL))
+            }
+        }
+
         for trackerURL in manualTrackerURLs where trackerURLs.insert(trackerURL).inserted {
             displayedTrackers.append(TorrentTracker(url: trackerURL))
         }

--- a/Harbor/Models/DownloadItem.swift
+++ b/Harbor/Models/DownloadItem.swift
@@ -95,6 +95,24 @@ struct DownloadActivityEvent: Codable, Identifiable, Hashable, Sendable {
     }
 }
 
+struct TorrentTracker: Codable, Identifiable, Hashable, Sendable {
+    let url: String
+    let status: String?
+    let errorMessage: String?
+
+    var id: String { url }
+
+    nonisolated init(
+        url: String,
+        status: String? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.url = url
+        self.status = status
+        self.errorMessage = errorMessage
+    }
+}
+
 struct DownloadRecord: Codable, Sendable {
     let id: UUID
     let sourceURL: URL
@@ -115,6 +133,8 @@ struct DownloadRecord: Codable, Sendable {
     let resumeData: Data?
     let backendIdentifier: String?
     let metadataName: String?
+    let torrentTrackers: [TorrentTracker]
+    let manualTrackerURLs: [String]
     let activityEvents: [DownloadActivityEvent]
 
     private enum CodingKeys: String, CodingKey {
@@ -137,6 +157,8 @@ struct DownloadRecord: Codable, Sendable {
         case resumeData
         case backendIdentifier
         case metadataName
+        case torrentTrackers
+        case manualTrackerURLs
         case activityEvents
     }
 
@@ -160,6 +182,8 @@ struct DownloadRecord: Codable, Sendable {
         resumeData: Data?,
         backendIdentifier: String?,
         metadataName: String?,
+        torrentTrackers: [TorrentTracker] = [],
+        manualTrackerURLs: [String] = [],
         activityEvents: [DownloadActivityEvent] = []
     ) {
         self.id = id
@@ -181,6 +205,8 @@ struct DownloadRecord: Codable, Sendable {
         self.resumeData = resumeData
         self.backendIdentifier = backendIdentifier
         self.metadataName = metadataName
+        self.torrentTrackers = torrentTrackers
+        self.manualTrackerURLs = manualTrackerURLs
         self.activityEvents = activityEvents
     }
 
@@ -205,6 +231,8 @@ struct DownloadRecord: Codable, Sendable {
         self.resumeData = try container.decodeIfPresent(Data.self, forKey: .resumeData)
         self.backendIdentifier = try container.decodeIfPresent(String.self, forKey: .backendIdentifier)
         self.metadataName = try container.decodeIfPresent(String.self, forKey: .metadataName)
+        self.torrentTrackers = try container.decodeIfPresent([TorrentTracker].self, forKey: .torrentTrackers) ?? []
+        self.manualTrackerURLs = try container.decodeIfPresent([String].self, forKey: .manualTrackerURLs) ?? []
         self.activityEvents = try container.decodeIfPresent([DownloadActivityEvent].self, forKey: .activityEvents) ?? []
     }
 
@@ -229,6 +257,8 @@ struct DownloadRecord: Codable, Sendable {
         try container.encode(resumeData, forKey: .resumeData)
         try container.encode(backendIdentifier, forKey: .backendIdentifier)
         try container.encode(metadataName, forKey: .metadataName)
+        try container.encode(torrentTrackers, forKey: .torrentTrackers)
+        try container.encode(manualTrackerURLs, forKey: .manualTrackerURLs)
         try container.encode(activityEvents, forKey: .activityEvents)
     }
 }
@@ -258,6 +288,8 @@ final class DownloadItem: Identifiable {
     var taskIdentifier: Int?
     var backendIdentifier: String?
     var metadataName: String?
+    var torrentTrackers: [TorrentTracker]
+    var manualTrackerURLs: [String]
     var activityEvents: [DownloadActivityEvent]
 
     init(
@@ -283,6 +315,8 @@ final class DownloadItem: Identifiable {
         taskIdentifier: Int? = nil,
         backendIdentifier: String? = nil,
         metadataName: String? = nil,
+        torrentTrackers: [TorrentTracker] = [],
+        manualTrackerURLs: [String] = [],
         activityEvents: [DownloadActivityEvent] = []
     ) {
         self.id = id
@@ -307,6 +341,8 @@ final class DownloadItem: Identifiable {
         self.taskIdentifier = taskIdentifier
         self.backendIdentifier = backendIdentifier
         self.metadataName = metadataName
+        self.torrentTrackers = torrentTrackers
+        self.manualTrackerURLs = manualTrackerURLs
         self.activityEvents = activityEvents
 
         if self.activityEvents.contains(where: { $0.kind == .added }) == false {
@@ -341,6 +377,8 @@ final class DownloadItem: Identifiable {
             taskIdentifier: nil,
             backendIdentifier: record.backendIdentifier,
             metadataName: record.metadataName,
+            torrentTrackers: record.torrentTrackers,
+            manualTrackerURLs: record.manualTrackerURLs,
             activityEvents: record.activityEvents
         )
     }
@@ -465,6 +503,21 @@ final class DownloadItem: Identifiable {
         lastError.map { Self.displayErrorMessage(from: $0) }
     }
 
+    var displayedTrackers: [TorrentTracker] {
+        var trackerURLs = Set<String>()
+        var displayedTrackers: [TorrentTracker] = []
+
+        for tracker in torrentTrackers where trackerURLs.insert(tracker.url).inserted {
+            displayedTrackers.append(tracker)
+        }
+
+        for trackerURL in manualTrackerURLs where trackerURLs.insert(trackerURL).inserted {
+            displayedTrackers.append(TorrentTracker(url: trackerURL))
+        }
+
+        return displayedTrackers
+    }
+
     var isRunning: Bool {
         status.isRunning
     }
@@ -498,6 +551,8 @@ final class DownloadItem: Identifiable {
             resumeData: resumeData,
             backendIdentifier: backendIdentifier,
             metadataName: metadataName,
+            torrentTrackers: torrentTrackers,
+            manualTrackerURLs: manualTrackerURLs,
             activityEvents: activityEvents
         )
     }

--- a/Harbor/Models/DownloadSource.swift
+++ b/Harbor/Models/DownloadSource.swift
@@ -57,6 +57,7 @@ enum DownloadBackend: String, Codable, Sendable {
 struct MagnetLinkMetadata: Sendable {
     let displayName: String?
     let infoHash: String?
+    let trackerURLs: [String]
 
     init(url: URL) {
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
@@ -73,6 +74,12 @@ struct MagnetLinkMetadata: Sendable {
             .last
             .map(String.init)?
             .nilIfBlank
+
+        var seenTrackerURLs = Set<String>()
+        self.trackerURLs = queryItems
+            .filter { $0.name.lowercased() == "tr" }
+            .compactMap { $0.value?.nilIfBlank }
+            .filter { seenTrackerURLs.insert($0).inserted }
     }
 }
 

--- a/Harbor/Services/Aria2TorrentService.swift
+++ b/Harbor/Services/Aria2TorrentService.swift
@@ -103,6 +103,7 @@ actor Aria2TorrentService {
     private var rpcSecret: String?
     private var stderrPipe: Pipe?
     private var transferSettings: DownloadTransferSettings
+    private var manualTrackerURLsByGID: [String: [String]] = [:]
 
     init(transferSettings: DownloadTransferSettings = .default) {
         self.transferSettings = transferSettings
@@ -149,10 +150,7 @@ actor Aria2TorrentService {
         logger.info("Starting torrent add request for source kind \(String(describing: sourceKind), privacy: .public)")
         try await ensureDaemonRunning()
 
-        let options = downloadOptions(
-            destinationFolderPath: destinationFolderPath,
-            manualTrackerURLs: manualTrackerURLs
-        )
+        let options = downloadOptions(destinationFolderPath: destinationFolderPath)
 
         switch sourceKind {
         case .magnetLink:
@@ -168,6 +166,9 @@ actor Aria2TorrentService {
                 as: String.self
             )
             logger.info("aria2 accepted magnet download with gid \(gid, privacy: .public)")
+            if manualTrackerURLs.isEmpty == false {
+                try await updateManualTrackers(gid: gid, trackerURLs: manualTrackerURLs)
+            }
             return gid
         case .torrentFile:
             let torrentData = try Data(contentsOf: sourceURL)
@@ -184,6 +185,9 @@ actor Aria2TorrentService {
                 as: String.self
             )
             logger.info("aria2 accepted torrent file with gid \(gid, privacy: .public)")
+            if manualTrackerURLs.isEmpty == false {
+                try await updateManualTrackers(gid: gid, trackerURLs: manualTrackerURLs)
+            }
             return gid
         case .directURL:
             throw TorrentEngineError.invalidSource
@@ -217,6 +221,14 @@ actor Aria2TorrentService {
     }
 
     func updateManualTrackers(gid: String, trackerURLs: [String]) async throws {
+        let previousTrackerURLs = manualTrackerURLsByGID[gid] ?? []
+        let existingTrackerURLs = try await currentTrackerURLs(gid: gid)
+        let preservedTrackerURLs = existingTrackerURLs.filter { trackerURL in
+            previousTrackerURLs.contains(trackerURL) == false
+                && trackerURLs.contains(trackerURL) == false
+        }
+        let mergedTrackerURLs = uniqueTrackerURLs(preservedTrackerURLs + trackerURLs)
+
         _ = try await rpcCallWithDaemonRestart(
             method: "aria2.changeOption",
             params: {
@@ -224,12 +236,13 @@ actor Aria2TorrentService {
                     try authorizedToken(),
                     gid,
                     [
-                        "bt-tracker": trackerURLs.joined(separator: ",")
+                        "bt-tracker": mergedTrackerURLs.joined(separator: ",")
                     ]
                 ]
             },
             as: String.self
         )
+        manualTrackerURLsByGID[gid] = trackerURLs
     }
 
     func remove(gid: String) async {
@@ -248,6 +261,7 @@ actor Aria2TorrentService {
             token,
             gid
         ], as: String.self)
+        manualTrackerURLsByGID[gid] = nil
     }
 
     func status(for gid: String) async throws -> TorrentStatusSnapshot {
@@ -390,19 +404,12 @@ actor Aria2TorrentService {
         return "token:\(rpcSecret)"
     }
 
-    private func downloadOptions(
-        destinationFolderPath: String,
-        manualTrackerURLs: [String]
-    ) -> [String: String] {
+    private func downloadOptions(destinationFolderPath: String) -> [String: String] {
         var options = [
             "dir": destinationFolderPath,
             "continue": "true",
             "pause": "false"
         ]
-
-        if manualTrackerURLs.isEmpty == false {
-            options["bt-tracker"] = manualTrackerURLs.joined(separator: ",")
-        }
 
         perDownloadOptions(transferSettings).forEach { key, value in
             options[key] = value
@@ -444,12 +451,39 @@ actor Aria2TorrentService {
         ], as: String.self)
     }
 
+    private func currentTrackerURLs(gid: String) async throws -> [String] {
+        let options = try await rpcCallWithDaemonRestart(
+            method: "aria2.getOption",
+            params: {
+                [
+                    try authorizedToken(),
+                    gid
+                ]
+            },
+            as: [String: String].self
+        )
+
+        return trackerURLs(from: options["bt-tracker"])
+    }
+
     private func aria2LimitString(_ bytesPerSecond: Int64?) -> String {
         guard let bytesPerSecond else {
             return "0"
         }
 
         return "\(max(bytesPerSecond, 0))"
+    }
+
+    private func trackerURLs(from option: String?) -> [String] {
+        option?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false } ?? []
+    }
+
+    private func uniqueTrackerURLs(_ trackerURLs: [String]) -> [String] {
+        var seenURLs = Set<String>()
+        return trackerURLs.filter { seenURLs.insert($0).inserted }
     }
 
     private func rpcCallWithDaemonRestart<Result: Decodable>(

--- a/Harbor/Services/Aria2TorrentService.swift
+++ b/Harbor/Services/Aria2TorrentService.swift
@@ -35,6 +35,7 @@ struct TorrentStatusSnapshot: Sendable {
     let errorMessage: String?
     let metadataName: String?
     let primaryPath: String?
+    let trackers: [TorrentTracker]
 }
 
 actor Aria2TorrentService {
@@ -70,6 +71,7 @@ actor Aria2TorrentService {
     }
 
     private struct BittorrentPayload: Decodable {
+        let announceList: [[String]]?
         let info: InfoPayload?
     }
 
@@ -141,12 +143,16 @@ actor Aria2TorrentService {
     func addDownload(
         sourceKind: DownloadSourceKind,
         sourceURL: URL,
-        destinationFolderPath: String
+        destinationFolderPath: String,
+        manualTrackerURLs: [String] = []
     ) async throws -> String {
         logger.info("Starting torrent add request for source kind \(String(describing: sourceKind), privacy: .public)")
         try await ensureDaemonRunning()
 
-        let options = downloadOptions(destinationFolderPath: destinationFolderPath)
+        let options = downloadOptions(
+            destinationFolderPath: destinationFolderPath,
+            manualTrackerURLs: manualTrackerURLs
+        )
 
         switch sourceKind {
         case .magnetLink:
@@ -210,6 +216,22 @@ actor Aria2TorrentService {
         )
     }
 
+    func updateManualTrackers(gid: String, trackerURLs: [String]) async throws {
+        _ = try await rpcCallWithDaemonRestart(
+            method: "aria2.changeOption",
+            params: {
+                [
+                    try authorizedToken(),
+                    gid,
+                    [
+                        "bt-tracker": trackerURLs.joined(separator: ",")
+                    ]
+                ]
+            },
+            as: String.self
+        )
+    }
+
     func remove(gid: String) async {
         guard process?.isRunning == true,
               rpcPort != nil,
@@ -264,7 +286,8 @@ actor Aria2TorrentService {
             uploadSpeed: Double(payload.uploadSpeed ?? "") ?? 0,
             errorMessage: payload.errorMessage,
             metadataName: payload.bittorrent?.info?.name,
-            primaryPath: preferredPath(from: filePaths)
+            primaryPath: preferredPath(from: filePaths),
+            trackers: trackers(from: payload.bittorrent?.announceList)
         )
     }
 
@@ -367,12 +390,19 @@ actor Aria2TorrentService {
         return "token:\(rpcSecret)"
     }
 
-    private func downloadOptions(destinationFolderPath: String) -> [String: String] {
+    private func downloadOptions(
+        destinationFolderPath: String,
+        manualTrackerURLs: [String]
+    ) -> [String: String] {
         var options = [
             "dir": destinationFolderPath,
             "continue": "true",
             "pause": "false"
         ]
+
+        if manualTrackerURLs.isEmpty == false {
+            options["bt-tracker"] = manualTrackerURLs.joined(separator: ",")
+        }
 
         perDownloadOptions(transferSettings).forEach { key, value in
             options[key] = value
@@ -632,5 +662,22 @@ actor Aria2TorrentService {
 
         let commonPath = NSString.path(withComponents: sharedComponents)
         return commonPath.isEmpty ? filePaths[0] : commonPath
+    }
+
+    private func trackers(from announceList: [[String]]?) -> [TorrentTracker] {
+        var seenURLs = Set<String>()
+        var trackers: [TorrentTracker] = []
+
+        for trackerURL in announceList?.flatMap({ $0 }) ?? [] {
+            guard trackerURL.isEmpty == false,
+                  seenURLs.insert(trackerURL).inserted else {
+                continue
+            }
+
+            // TODO: Add per-tracker status/error here if aria2 exposes it through JSON-RPC.
+            trackers.append(TorrentTracker(url: trackerURL))
+        }
+
+        return trackers
     }
 }

--- a/Harbor/ViewModels/DownloadCenter.swift
+++ b/Harbor/ViewModels/DownloadCenter.swift
@@ -16,6 +16,7 @@ final class DownloadCenter {
     @ObservationIgnored private var hasInstalledExternalOpenHandler = false
     @ObservationIgnored private var persistTask: Task<Void, Never>?
     @ObservationIgnored private var torrentRefreshTask: Task<Void, Never>?
+    @ObservationIgnored private var trackerSyncTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored private var hasShownTorrentBinaryAlert = false
     @ObservationIgnored private var pendingExternalAddSheetDrafts: [AddDownloadSheetDraft] = []
 
@@ -58,6 +59,7 @@ final class DownloadCenter {
     deinit {
         persistTask?.cancel()
         torrentRefreshTask?.cancel()
+        trackerSyncTasks.values.forEach { $0.cancel() }
     }
 
     func initializeIfNeeded() async {
@@ -558,8 +560,7 @@ final class DownloadCenter {
             return false
         }
 
-        guard item.manualTrackerURLs.contains(trackerURL) == false,
-              item.torrentTrackers.contains(where: { $0.url == trackerURL }) == false else {
+        guard item.displayedTrackers.contains(where: { $0.url == trackerURL }) == false else {
             return false
         }
 
@@ -1519,32 +1520,54 @@ final class DownloadCenter {
     }
 
     private func syncManualTrackers(for item: DownloadItem) {
-        guard let backendIdentifier = item.backendIdentifier else {
+        let itemID = item.id
+        guard item.backendIdentifier != nil,
+              trackerSyncTasks[itemID] == nil else {
             return
         }
 
-        let itemID = item.id
-        let trackerURLs = item.manualTrackerURLs
-
-        Task { @MainActor [weak self] in
+        trackerSyncTasks[itemID] = Task { @MainActor [weak self] in
             guard let self else {
                 return
             }
 
-            do {
-                try await self.torrentService.updateManualTrackers(
-                    gid: backendIdentifier,
-                    trackerURLs: trackerURLs
-                )
-                await self.refreshTorrentDownload(id: itemID)
-            } catch {
+            defer {
+                self.trackerSyncTasks[itemID] = nil
+            }
+
+            while Task.isCancelled == false {
                 guard let item = self.item(for: itemID) else {
                     return
                 }
 
-                item.lastError = error.localizedDescription
-                item.updatedAt = .now
-                self.schedulePersist()
+                guard let backendIdentifier = item.backendIdentifier else {
+                    return
+                }
+
+                let trackerURLs = item.manualTrackerURLs
+
+                do {
+                    try await self.torrentService.updateManualTrackers(
+                        gid: backendIdentifier,
+                        trackerURLs: trackerURLs
+                    )
+                    await self.refreshTorrentDownload(id: itemID)
+                } catch {
+                    guard let item = self.item(for: itemID) else {
+                        return
+                    }
+
+                    item.lastError = error.localizedDescription
+                    item.updatedAt = .now
+                    self.schedulePersist()
+                    return
+                }
+
+                guard let latestItem = self.item(for: itemID),
+                      latestItem.backendIdentifier == backendIdentifier,
+                      latestItem.manualTrackerURLs != trackerURLs else {
+                    return
+                }
             }
         }
     }

--- a/Harbor/ViewModels/DownloadCenter.swift
+++ b/Harbor/ViewModels/DownloadCenter.swift
@@ -543,6 +543,54 @@ final class DownloadCenter {
         pasteboard.setString(sourceText, forType: .string)
     }
 
+    @discardableResult
+    func addTracker(_ rawURL: String, to id: UUID) -> Bool {
+        guard let item = item(for: id),
+              item.backend == .aria2 else {
+            return false
+        }
+
+        guard let trackerURL = normalizedTrackerURL(from: rawURL) else {
+            activeAlert = UserAlert(
+                title: "Invalid Tracker URL",
+                message: "Enter an http, https, or udp tracker URL with a host."
+            )
+            return false
+        }
+
+        guard item.manualTrackerURLs.contains(trackerURL) == false,
+              item.torrentTrackers.contains(where: { $0.url == trackerURL }) == false else {
+            return false
+        }
+
+        item.manualTrackerURLs.append(trackerURL)
+        item.torrentTrackers.append(TorrentTracker(url: trackerURL))
+        item.updatedAt = .now
+        schedulePersist()
+        syncManualTrackers(for: item)
+        return true
+    }
+
+    func removeManualTracker(_ trackerURL: String, from id: UUID) {
+        guard let item = item(for: id),
+              item.backend == .aria2,
+              item.manualTrackerURLs.contains(trackerURL) else {
+            return
+        }
+
+        item.manualTrackerURLs.removeAll { $0 == trackerURL }
+        item.torrentTrackers.removeAll { $0.url == trackerURL }
+        item.updatedAt = .now
+        schedulePersist()
+        syncManualTrackers(for: item)
+    }
+
+    func refreshTorrentTrackers(id: UUID) {
+        Task { @MainActor [weak self] in
+            await self?.refreshTorrentDownload(id: id)
+        }
+    }
+
     func continueInBrowser(id: UUID) {
         guard let item = item(for: id),
               item.sourceKind == .directURL
@@ -649,7 +697,8 @@ final class DownloadCenter {
                     let replacementIdentifier = try await torrentService.addDownload(
                         sourceKind: refreshedItem.sourceKind,
                         sourceURL: refreshedItem.sourceURL,
-                        destinationFolderPath: refreshedItem.destinationFolderPath
+                        destinationFolderPath: refreshedItem.destinationFolderPath,
+                        manualTrackerURLs: refreshedItem.manualTrackerURLs
                     )
 
                     guard let refreshedItem = item(for: id) else {
@@ -663,7 +712,8 @@ final class DownloadCenter {
                 let backendIdentifier = try await torrentService.addDownload(
                     sourceKind: currentItem.sourceKind,
                     sourceURL: currentItem.sourceURL,
-                    destinationFolderPath: currentItem.destinationFolderPath
+                    destinationFolderPath: currentItem.destinationFolderPath,
+                    manualTrackerURLs: currentItem.manualTrackerURLs
                 )
                 guard let refreshedItem = item(for: id) else {
                     await torrentService.remove(gid: backendIdentifier)
@@ -850,6 +900,7 @@ final class DownloadCenter {
         item.speedBytesPerSecond = snapshot.downloadSpeed
         item.uploadBytesPerSecond = snapshot.uploadSpeed
         item.metadataName = snapshot.metadataName ?? item.metadataName
+        item.torrentTrackers = snapshot.trackers
         item.updatedAt = .now
 
         if let primaryPath = snapshot.primaryPath {
@@ -1465,6 +1516,74 @@ final class DownloadCenter {
             defaultValue: "Torrent Engine Error",
             comment: "Alert title shown when the torrent backend reports an error."
         )
+    }
+
+    private func syncManualTrackers(for item: DownloadItem) {
+        guard let backendIdentifier = item.backendIdentifier else {
+            return
+        }
+
+        let itemID = item.id
+        let trackerURLs = item.manualTrackerURLs
+
+        Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+
+            do {
+                try await self.torrentService.updateManualTrackers(
+                    gid: backendIdentifier,
+                    trackerURLs: trackerURLs
+                )
+                await self.refreshTorrentDownload(id: itemID)
+            } catch {
+                guard let item = self.item(for: itemID) else {
+                    return
+                }
+
+                item.lastError = error.localizedDescription
+                item.updatedAt = .now
+                self.schedulePersist()
+            }
+        }
+    }
+
+    private func refreshTorrentDownload(id: UUID) async {
+        guard let currentItem = item(for: id),
+              currentItem.backend == .aria2,
+              let backendIdentifier = currentItem.backendIdentifier else {
+            return
+        }
+
+        do {
+            let snapshot = try await torrentService.status(for: backendIdentifier)
+            guard let refreshedItem = item(for: id) else {
+                return
+            }
+
+            apply(snapshot: snapshot, to: refreshedItem)
+            schedulePersist()
+        } catch {
+            currentItem.lastError = error.localizedDescription
+            currentItem.updatedAt = .now
+            schedulePersist()
+        }
+    }
+
+    private func normalizedTrackerURL(from rawURL: String) -> String? {
+        let trimmedURL = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedURL.isEmpty == false,
+              var components = URLComponents(string: trimmedURL),
+              let scheme = components.scheme?.lowercased(),
+              ["http", "https", "udp"].contains(scheme),
+              let host = components.host,
+              host.isEmpty == false else {
+            return nil
+        }
+
+        components.scheme = scheme
+        return components.url?.absoluteString
     }
 
     private func schedulePersist() {

--- a/Harbor/Views/DownloadDetailView.swift
+++ b/Harbor/Views/DownloadDetailView.swift
@@ -35,6 +35,9 @@ private struct DownloadInspectorContent: View {
 
                 DownloadTransferSection(item: item)
                 DownloadStorageSection(item: item)
+                if item.backend == .aria2 {
+                    DownloadTrackersSection(item: item, center: center)
+                }
                 DownloadActivitySection(item: item)
 
                 if item.status == .browserSessionRequired {
@@ -443,6 +446,144 @@ private struct DownloadStorageSection: View {
                     DownloadValueRow(title: "Saved File", value: fileLocationPath)
                 }
             }
+        }
+    }
+}
+
+private struct DownloadTrackersSection: View {
+    let item: DownloadItem
+    let center: DownloadCenter
+
+    @State private var trackerURL = ""
+
+    var body: some View {
+        DownloadDetailSection(title: "Trackers") {
+            VStack(alignment: .leading, spacing: 10) {
+                trackerInput
+
+                if item.displayedTrackers.isEmpty {
+                    Text("No trackers reported yet.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .padding(.vertical, 9)
+                } else {
+                    VStack(spacing: 0) {
+                        let trackers = item.displayedTrackers
+
+                        ForEach(Array(trackers.enumerated()), id: \.element.id) { index, tracker in
+                            TorrentTrackerRow(
+                                tracker: tracker,
+                                isManual: item.manualTrackerURLs.contains(tracker.url),
+                                remove: {
+                                    center.removeManualTracker(tracker.url, from: item.id)
+                                }
+                            )
+
+                            if index < trackers.count - 1 {
+                                Divider()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var trackerInput: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                trackerTextField
+                addButton
+                refreshButton
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                trackerTextField
+                HStack(spacing: 8) {
+                    addButton
+                    refreshButton
+                }
+            }
+        }
+    }
+
+    private var trackerTextField: some View {
+        TextField("Tracker URL", text: $trackerURL)
+            .textFieldStyle(.roundedBorder)
+            .frame(minWidth: 220)
+            .onSubmit(addTracker)
+    }
+
+    private var addButton: some View {
+        Button(action: addTracker) {
+            Label("Add", systemImage: "plus")
+        }
+        .buttonStyle(LiquidPillButtonStyle(prominent: false))
+        .disabled(trackerURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    private var refreshButton: some View {
+        Button {
+            center.refreshTorrentTrackers(id: item.id)
+        } label: {
+            Label("Refresh", systemImage: "arrow.clockwise")
+        }
+        .buttonStyle(LiquidPillButtonStyle(prominent: false))
+        .help("Refresh tracker list")
+    }
+
+    private func addTracker() {
+        if center.addTracker(trackerURL, to: item.id) {
+            trackerURL = ""
+        }
+    }
+}
+
+private struct TorrentTrackerRow: View {
+    let tracker: TorrentTracker
+    let isManual: Bool
+    let remove: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(tracker.url)
+                    .font(.callout)
+                    .lineLimit(2)
+                    .textSelection(.enabled)
+
+                trackerMetadata
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if isManual {
+                Button(action: remove) {
+                    Image(systemName: "minus.circle")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Remove tracker")
+            }
+        }
+        .padding(.vertical, 9)
+    }
+
+    @ViewBuilder
+    private var trackerMetadata: some View {
+        if let errorMessage = tracker.errorMessage, errorMessage.isEmpty == false {
+            Text(errorMessage)
+                .font(.caption)
+                .foregroundStyle(.red)
+                .lineLimit(2)
+                .textSelection(.enabled)
+        } else if let status = tracker.status, status.isEmpty == false {
+            Text(status)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else if isManual {
+            Text("Manual")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
         }
     }
 }

--- a/Harbor/Views/HarborPreviewFixtures.swift
+++ b/Harbor/Views/HarborPreviewFixtures.swift
@@ -46,7 +46,13 @@ enum HarborPreviewFixtures {
             startedAt: now.addingTimeInterval(-3_420),
             updatedAt: now.addingTimeInterval(-120),
             backendIdentifier: "preview-torrent",
-            metadataName: "Cold Storage (2026) [1080p] [WEBRip] [x265]"
+            metadataName: "Cold Storage (2026) [1080p] [WEBRip] [x265]",
+            torrentTrackers: [
+                TorrentTracker(url: "udp://tracker.opentrackr.org:1337/announce")
+            ],
+            manualTrackerURLs: [
+                "https://tracker.example.com/announce"
+            ]
         )
 
         let direct = DownloadItem(
@@ -83,7 +89,14 @@ enum HarborPreviewFixtures {
             startedAt: now.addingTimeInterval(-840),
             updatedAt: now.addingTimeInterval(-8),
             backendIdentifier: "preview-magnet",
-            metadataName: "Ubuntu ISO"
+            metadataName: "Ubuntu ISO",
+            torrentTrackers: [
+                TorrentTracker(url: "udp://tracker.openbittorrent.com:6969/announce"),
+                TorrentTracker(url: "https://tracker.example.org/announce")
+            ],
+            manualTrackerURLs: [
+                "https://tracker.example.org/announce"
+            ]
         )
 
         let failed = DownloadItem(


### PR DESCRIPTION
## Summary
- Adds persisted torrent tracker state for aria2 downloads.
- Shows tracker URLs in the download detail inspector with add, remove, and refresh actions.
- Applies Harbor-added trackers through aria2 `bt-tracker` options when starting or updating torrents.

Closes #16

## Validation
- `git diff --check`
- `xcodebuild -project Harbor.xcodeproj -scheme Harbor -configuration Debug -derivedDataPath /tmp/HarborDerivedData CODE_SIGNING_ALLOWED=NO build`