### PR TITLE
Add manual download tags

### DIFF
--- a/Harbor/Models/AddDownloadRequest.swift
+++ b/Harbor/Models/AddDownloadRequest.swift
@@ -4,6 +4,7 @@ struct AddDownloadRequest: Sendable {
     let sourceKind: DownloadSourceKind
     let sourceURL: URL
     let customFilename: String?
+    let tags: [String]
     let destinationFolder: URL
     let shouldStartImmediately: Bool
 }

--- a/Harbor/Models/AddDownloadSheetDraft.swift
+++ b/Harbor/Models/AddDownloadSheetDraft.swift
@@ -21,6 +21,7 @@ struct AddDownloadSheetDraft: Identifiable, Sendable {
     let entryMode: AddDownloadEntryMode
     let sourceURLText: String
     let customFilename: String
+    let tags: [String]
     let torrentFileURL: URL?
     let destinationFolderURL: URL
     let shouldStartImmediately: Bool
@@ -30,6 +31,7 @@ struct AddDownloadSheetDraft: Identifiable, Sendable {
         entryMode: AddDownloadEntryMode,
         sourceURLText: String = "",
         customFilename: String = "",
+        tags: [String] = [],
         torrentFileURL: URL? = nil,
         destinationFolderURL: URL,
         shouldStartImmediately: Bool
@@ -38,6 +40,7 @@ struct AddDownloadSheetDraft: Identifiable, Sendable {
         self.entryMode = entryMode
         self.sourceURLText = sourceURLText
         self.customFilename = customFilename
+        self.tags = DownloadTags.normalized(tags)
         self.torrentFileURL = torrentFileURL
         self.destinationFolderURL = destinationFolderURL
         self.shouldStartImmediately = shouldStartImmediately

--- a/Harbor/Models/DownloadFilter.swift
+++ b/Harbor/Models/DownloadFilter.swift
@@ -80,6 +80,48 @@ enum DownloadFilter: String, CaseIterable, Identifiable, Hashable {
     }
 }
 
+enum DownloadSidebarSelection: Hashable, Identifiable {
+    case filter(DownloadFilter)
+    case tag(String)
+
+    var id: String {
+        switch self {
+        case .filter(let filter):
+            "filter-\(filter.rawValue)"
+        case .tag(let tag):
+            "tag-\(tag.lowercased())"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .filter(let filter):
+            String(localized: filter.title)
+        case .tag(let tag):
+            tag
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .filter(let filter):
+            filter.systemImage
+        case .tag:
+            "tag"
+        }
+    }
+
+    @MainActor
+    func includes(_ item: DownloadItem) -> Bool {
+        switch self {
+        case .filter(let filter):
+            filter.includes(item)
+        case .tag(let tag):
+            DownloadTags.contains(item.tags, tag: tag)
+        }
+    }
+}
+
 enum DownloadSortMode: String, CaseIterable, Identifiable {
     case newest
     case oldest

--- a/Harbor/Models/DownloadItem.swift
+++ b/Harbor/Models/DownloadItem.swift
@@ -115,6 +115,7 @@ struct DownloadRecord: Codable, Sendable {
     let resumeData: Data?
     let backendIdentifier: String?
     let metadataName: String?
+    let tags: [String]
     let activityEvents: [DownloadActivityEvent]
 
     private enum CodingKeys: String, CodingKey {
@@ -137,6 +138,7 @@ struct DownloadRecord: Codable, Sendable {
         case resumeData
         case backendIdentifier
         case metadataName
+        case tags
         case activityEvents
     }
 
@@ -160,6 +162,7 @@ struct DownloadRecord: Codable, Sendable {
         resumeData: Data?,
         backendIdentifier: String?,
         metadataName: String?,
+        tags: [String] = [],
         activityEvents: [DownloadActivityEvent] = []
     ) {
         self.id = id
@@ -181,6 +184,7 @@ struct DownloadRecord: Codable, Sendable {
         self.resumeData = resumeData
         self.backendIdentifier = backendIdentifier
         self.metadataName = metadataName
+        self.tags = DownloadTags.normalized(tags)
         self.activityEvents = activityEvents
     }
 
@@ -205,6 +209,7 @@ struct DownloadRecord: Codable, Sendable {
         self.resumeData = try container.decodeIfPresent(Data.self, forKey: .resumeData)
         self.backendIdentifier = try container.decodeIfPresent(String.self, forKey: .backendIdentifier)
         self.metadataName = try container.decodeIfPresent(String.self, forKey: .metadataName)
+        self.tags = DownloadTags.normalized(try container.decodeIfPresent([String].self, forKey: .tags) ?? [])
         self.activityEvents = try container.decodeIfPresent([DownloadActivityEvent].self, forKey: .activityEvents) ?? []
     }
 
@@ -229,6 +234,7 @@ struct DownloadRecord: Codable, Sendable {
         try container.encode(resumeData, forKey: .resumeData)
         try container.encode(backendIdentifier, forKey: .backendIdentifier)
         try container.encode(metadataName, forKey: .metadataName)
+        try container.encode(tags, forKey: .tags)
         try container.encode(activityEvents, forKey: .activityEvents)
     }
 }
@@ -258,6 +264,7 @@ final class DownloadItem: Identifiable {
     var taskIdentifier: Int?
     var backendIdentifier: String?
     var metadataName: String?
+    var tags: [String]
     var activityEvents: [DownloadActivityEvent]
 
     init(
@@ -283,6 +290,7 @@ final class DownloadItem: Identifiable {
         taskIdentifier: Int? = nil,
         backendIdentifier: String? = nil,
         metadataName: String? = nil,
+        tags: [String] = [],
         activityEvents: [DownloadActivityEvent] = []
     ) {
         self.id = id
@@ -307,6 +315,7 @@ final class DownloadItem: Identifiable {
         self.taskIdentifier = taskIdentifier
         self.backendIdentifier = backendIdentifier
         self.metadataName = metadataName
+        self.tags = DownloadTags.normalized(tags)
         self.activityEvents = activityEvents
 
         if self.activityEvents.contains(where: { $0.kind == .added }) == false {
@@ -341,6 +350,7 @@ final class DownloadItem: Identifiable {
             taskIdentifier: nil,
             backendIdentifier: record.backendIdentifier,
             metadataName: record.metadataName,
+            tags: record.tags,
             activityEvents: record.activityEvents
         )
     }
@@ -498,6 +508,7 @@ final class DownloadItem: Identifiable {
             resumeData: resumeData,
             backendIdentifier: backendIdentifier,
             metadataName: metadataName,
+            tags: tags,
             activityEvents: activityEvents
         )
     }
@@ -565,5 +576,38 @@ final class DownloadItem: Identifiable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         return path.isEmpty ? nil : path
+    }
+}
+
+enum DownloadTags {
+    static func normalized(_ tags: [String]) -> [String] {
+        var seen = Set<String>()
+
+        // TODO: ponytail: keep tags manual; add automatic rules only when users need them.
+        return tags.compactMap { tag in
+            let trimmed = tag.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.isEmpty == false else {
+                return nil
+            }
+
+            let key = trimmed.lowercased()
+            guard seen.insert(key).inserted else {
+                return nil
+            }
+
+            return trimmed
+        }
+    }
+
+    static func parsed(from text: String) -> [String] {
+        normalized(text.split(separator: ",", omittingEmptySubsequences: false).map(String.init))
+    }
+
+    static func text(from tags: [String]) -> String {
+        normalized(tags).joined(separator: ", ")
+    }
+
+    static func contains(_ tags: [String], tag: String) -> Bool {
+        tags.contains { $0.caseInsensitiveCompare(tag) == .orderedSame }
     }
 }

--- a/Harbor/ViewModels/DownloadCenter.swift
+++ b/Harbor/ViewModels/DownloadCenter.swift
@@ -20,7 +20,7 @@ final class DownloadCenter {
     @ObservationIgnored private var pendingExternalAddSheetDrafts: [AddDownloadSheetDraft] = []
 
     var downloads: [DownloadItem] = []
-    var selectedFilter: DownloadFilter = .all
+    var selectedSidebarSelection: DownloadSidebarSelection = .filter(.all)
     var selectedDownloadID: UUID?
     var searchText = ""
     var sortMode: DownloadSortMode = .newest
@@ -115,7 +115,7 @@ final class DownloadCenter {
 
     var filteredDownloads: [DownloadItem] {
         let filtered = downloads.filter { item in
-            guard selectedFilter.includes(item) else {
+            guard selectedSidebarSelection.includes(item) else {
                 return false
             }
 
@@ -127,6 +127,7 @@ final class DownloadCenter {
             return item.displayName.localizedCaseInsensitiveContains(query)
                 || item.sourceDisplayText.localizedCaseInsensitiveContains(query)
                 || item.sourceHost.localizedCaseInsensitiveContains(query)
+                || item.tags.contains { $0.localizedCaseInsensitiveContains(query) }
         }
 
         switch sortMode {
@@ -229,8 +230,30 @@ final class DownloadCenter {
         selectedDownload?.fileLocationURL != nil
     }
 
+    var availableTags: [String] {
+        var seen = Set<String>()
+        var tags: [String] = []
+
+        for tag in downloads.flatMap(\.tags) {
+            let key = tag.lowercased()
+            guard seen.insert(key).inserted else {
+                continue
+            }
+
+            tags.append(tag)
+        }
+
+        return tags.sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }
+    }
+
     func count(for filter: DownloadFilter) -> Int {
         downloads.filter { filter.includes($0) }.count
+    }
+
+    func count(forTag tag: String) -> Int {
+        downloads.filter { DownloadTags.contains($0.tags, tag: tag) }.count
     }
 
     func installExternalOpenHandlerIfNeeded() {
@@ -299,7 +322,8 @@ final class DownloadCenter {
             backend: backend,
             preferredFilename: preferredFilename,
             destinationFolderPath: request.destinationFolder.path,
-            status: request.shouldStartImmediately ? .queued : .paused
+            status: request.shouldStartImmediately ? .queued : .paused,
+            tags: request.tags
         )
 
         if request.sourceKind == .magnetLink {
@@ -471,9 +495,7 @@ final class DownloadCenter {
 
         downloads.removeAll { $0.id == id }
 
-        if selectedDownloadID == id {
-            selectedDownloadID = filteredDownloads.first?.id ?? downloads.first?.id
-        }
+        repairSelectionIfNeeded()
 
         schedulePersist()
         startNextQueuedDownloadsIfNeeded()
@@ -482,18 +504,30 @@ final class DownloadCenter {
     func clearCompleted() {
         cleanupBackendIdentifiers(for: downloads.filter { $0.status == .completed })
         downloads.removeAll { $0.status == .completed }
-        if selectedDownload?.status == .completed {
-            selectedDownloadID = filteredDownloads.first?.id ?? downloads.first?.id
-        }
+        repairSelectionIfNeeded()
         schedulePersist()
     }
 
     func clearFailed() {
         cleanupBackendIdentifiers(for: downloads.filter { $0.status == .failed })
         downloads.removeAll { $0.status == .failed }
-        if selectedDownload?.status == .failed {
-            selectedDownloadID = filteredDownloads.first?.id ?? downloads.first?.id
+        repairSelectionIfNeeded()
+        schedulePersist()
+    }
+
+    func setTags(for id: UUID, tags: [String]) {
+        guard let item = item(for: id) else {
+            return
         }
+
+        let normalizedTags = DownloadTags.normalized(tags)
+        guard item.tags != normalizedTags else {
+            return
+        }
+
+        item.tags = normalizedTags
+        item.updatedAt = .now
+        repairSelectionIfNeeded()
         schedulePersist()
     }
 
@@ -1082,6 +1116,24 @@ final class DownloadCenter {
 
     private func item(for id: UUID) -> DownloadItem? {
         downloads.first { $0.id == id }
+    }
+
+    private func repairSelectionIfNeeded() {
+        if case .tag(let tag) = selectedSidebarSelection {
+            if let displayTag = availableTags.first(where: { $0.caseInsensitiveCompare(tag) == .orderedSame }) {
+                selectedSidebarSelection = .tag(displayTag)
+            } else {
+                selectedSidebarSelection = .filter(.all)
+            }
+        }
+
+        guard let selectedDownloadID,
+              filteredDownloads.contains(where: { $0.id == selectedDownloadID }) == false
+        else {
+            return
+        }
+
+        self.selectedDownloadID = filteredDownloads.first?.id ?? downloads.first?.id
     }
 
     private func finalizeFileDownload(

--- a/Harbor/Views/AddDownloadSheet.swift
+++ b/Harbor/Views/AddDownloadSheet.swift
@@ -5,6 +5,7 @@ struct AddDownloadSheet: View {
     private enum Field: Hashable {
         case sourceURL
         case filename
+        case tags
     }
 
     let settings: AppSettingsStore
@@ -16,6 +17,7 @@ struct AddDownloadSheet: View {
     @State private var entryMode: AddDownloadEntryMode
     @State private var sourceURLText: String
     @State private var customFilename: String
+    @State private var tagsText: String
     @State private var torrentFileURL: URL?
     @State private var destinationPath: String
     @State private var shouldStartImmediately: Bool
@@ -31,6 +33,7 @@ struct AddDownloadSheet: View {
         _entryMode = State(initialValue: draft.entryMode)
         _sourceURLText = State(initialValue: draft.sourceURLText)
         _customFilename = State(initialValue: draft.customFilename)
+        _tagsText = State(initialValue: DownloadTags.text(from: draft.tags))
         _torrentFileURL = State(initialValue: draft.torrentFileURL)
         _destinationPath = State(initialValue: draft.destinationFolderURL.path)
         _shouldStartImmediately = State(initialValue: draft.shouldStartImmediately)
@@ -75,6 +78,9 @@ struct AddDownloadSheet: View {
                         }
                     }
                 }
+
+                TextField("Tags, separated by commas", text: $tagsText)
+                    .focused($focusedField, equals: Field.tags)
 
                 destinationPicker
 
@@ -218,6 +224,7 @@ struct AddDownloadSheet: View {
                 sourceKind: sourceKind,
                 sourceURL: sourceURL,
                 customFilename: sourceKind.supportsCustomFilename && trimmedFilename.isEmpty == false ? trimmedFilename : nil,
+                tags: DownloadTags.parsed(from: tagsText),
                 destinationFolder: folderURL,
                 shouldStartImmediately: shouldStartImmediately
             )

--- a/Harbor/Views/DownloadDetailView.swift
+++ b/Harbor/Views/DownloadDetailView.swift
@@ -35,6 +35,7 @@ private struct DownloadInspectorContent: View {
 
                 DownloadTransferSection(item: item)
                 DownloadStorageSection(item: item)
+                DownloadTagsSection(item: item, center: center)
                 DownloadActivitySection(item: item)
 
                 if item.status == .browserSessionRequired {
@@ -444,6 +445,76 @@ private struct DownloadStorageSection: View {
                 }
             }
         }
+    }
+}
+
+private struct DownloadTagsSection: View {
+    let item: DownloadItem
+    let center: DownloadCenter
+
+    @State private var newTagText = ""
+
+    var body: some View {
+        DownloadDetailSection(title: "Tags") {
+            VStack(alignment: .leading, spacing: 10) {
+                if item.tags.isEmpty {
+                    Text("No tags")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .padding(.vertical, 4)
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(Array(item.tags.enumerated()), id: \.element) { index, tag in
+                            HStack(spacing: 8) {
+                                Label(tag, systemImage: "tag")
+                                    .lineLimit(1)
+
+                                Spacer()
+
+                                Button {
+                                    removeTag(tag)
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Remove tag")
+                            }
+                            .padding(.vertical, 6)
+
+                            if index < item.tags.count - 1 {
+                                Divider()
+                            }
+                        }
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    TextField("Add tag", text: $newTagText)
+                        .onSubmit(addTags)
+
+                    Button("Add", systemImage: "plus", action: addTags)
+                        .disabled(DownloadTags.parsed(from: newTagText).isEmpty)
+                }
+            }
+        }
+    }
+
+    private func addTags() {
+        let tags = DownloadTags.parsed(from: newTagText)
+        guard tags.isEmpty == false else {
+            return
+        }
+
+        center.setTags(for: item.id, tags: item.tags + tags)
+        newTagText = ""
+    }
+
+    private func removeTag(_ tag: String) {
+        center.setTags(
+            for: item.id,
+            tags: item.tags.filter { $0.caseInsensitiveCompare(tag) != .orderedSame }
+        )
     }
 }
 

--- a/Harbor/Views/DownloadsContentView.swift
+++ b/Harbor/Views/DownloadsContentView.swift
@@ -66,7 +66,7 @@ struct DownloadsContentView: View {
                 }
             }
         }
-        .navigationTitle(center.selectedFilter.title)
+        .navigationTitle(center.selectedSidebarSelection.title)
     }
 
     private var emptyState: some View {
@@ -82,41 +82,51 @@ struct DownloadsContentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private var emptyTitle: LocalizedStringResource {
-        switch center.selectedFilter {
-        case .all:
-            "No Downloads Yet"
-        case .active:
-            "Nothing Running"
-        case .paused:
-            "No Paused Downloads"
-        case .completed:
-            "Nothing Completed"
-        case .failed:
-            "No Failures"
-        case .cancelled:
-            "No Cancelled Downloads"
+    private var emptyTitle: String {
+        switch center.selectedSidebarSelection {
+        case .filter(let filter):
+            switch filter {
+            case .all:
+                "No Downloads Yet"
+            case .active:
+                "Nothing Running"
+            case .paused:
+                "No Paused Downloads"
+            case .completed:
+                "Nothing Completed"
+            case .failed:
+                "No Failures"
+            case .cancelled:
+                "No Cancelled Downloads"
+            }
+        case .tag(let tag):
+            "No Downloads Tagged \"\(tag)\""
         }
     }
 
     private var emptyImage: String {
-        center.selectedFilter.systemImage
+        center.selectedSidebarSelection.systemImage
     }
 
-    private var emptyDescription: LocalizedStringResource {
-        switch center.selectedFilter {
-        case .all:
-            "Paste an HTTP or HTTPS URL to start building your queue."
-        case .active:
-            "Queued and running transfers appear here."
-        case .paused:
-            "Paused transfers and browser-required downloads stay here until you continue them."
-        case .completed:
-            "Finished files will stay listed until you clear them."
-        case .failed:
-            "Network or filesystem errors surface here with retry support."
-        case .cancelled:
-            "Cancelled items stay in history until you remove them."
+    private var emptyDescription: String {
+        switch center.selectedSidebarSelection {
+        case .filter(let filter):
+            switch filter {
+            case .all:
+                "Paste an HTTP or HTTPS URL to start building your queue."
+            case .active:
+                "Queued and running transfers appear here."
+            case .paused:
+                "Paused transfers and browser-required downloads stay here until you continue them."
+            case .completed:
+                "Finished files will stay listed until you clear them."
+            case .failed:
+                "Network or filesystem errors surface here with retry support."
+            case .cancelled:
+                "Cancelled items stay in history until you remove them."
+            }
+        case .tag:
+            "Add this tag to a download from the detail inspector or the Add Download sheet."
         }
     }
 

--- a/Harbor/Views/HarborPreviewFixtures.swift
+++ b/Harbor/Views/HarborPreviewFixtures.swift
@@ -16,13 +16,13 @@ enum HarborPreviewFixtures {
     }
 
     static func makeCenter(
-        selectedFilter: DownloadFilter = .all,
+        selectedSidebarSelection: DownloadSidebarSelection = .filter(.all),
         selectedDownloadIndex: Int = 1
     ) -> DownloadCenter {
         let settings = makeSettings()
         let center = DownloadCenter(settings: settings)
         center.downloads = sampleDownloads()
-        center.selectedFilter = selectedFilter
+        center.selectedSidebarSelection = selectedSidebarSelection
         center.selectedDownloadID = center.downloads[safe: selectedDownloadIndex]?.id
         return center
     }
@@ -46,7 +46,8 @@ enum HarborPreviewFixtures {
             startedAt: now.addingTimeInterval(-3_420),
             updatedAt: now.addingTimeInterval(-120),
             backendIdentifier: "preview-torrent",
-            metadataName: "Cold Storage (2026) [1080p] [WEBRip] [x265]"
+            metadataName: "Cold Storage (2026) [1080p] [WEBRip] [x265]",
+            tags: ["Movies", "Archive"]
         )
 
         let direct = DownloadItem(
@@ -64,7 +65,8 @@ enum HarborPreviewFixtures {
             speedBytesPerSecond: 0,
             startedAt: now.addingTimeInterval(-7_100),
             finishedAt: now.addingTimeInterval(-6_900),
-            updatedAt: now.addingTimeInterval(-6_900)
+            updatedAt: now.addingTimeInterval(-6_900),
+            tags: ["Apps"]
         )
 
         let magnet = DownloadItem(
@@ -83,7 +85,8 @@ enum HarborPreviewFixtures {
             startedAt: now.addingTimeInterval(-840),
             updatedAt: now.addingTimeInterval(-8),
             backendIdentifier: "preview-magnet",
-            metadataName: "Ubuntu ISO"
+            metadataName: "Ubuntu ISO",
+            tags: ["Linux", "ISO"]
         )
 
         let failed = DownloadItem(
@@ -100,7 +103,8 @@ enum HarborPreviewFixtures {
             speedBytesPerSecond: 0,
             startedAt: now.addingTimeInterval(-1_760),
             updatedAt: now.addingTimeInterval(-300),
-            lastError: "The network connection was lost."
+            lastError: "The network connection was lost.",
+            tags: ["Archive"]
         )
 
         return [magnet, torrent, direct, failed]

--- a/Harbor/Views/SidebarView.swift
+++ b/Harbor/Views/SidebarView.swift
@@ -6,7 +6,7 @@ struct SidebarView: View {
     var body: some View {
         @Bindable var center = center
 
-        List(selection: $center.selectedFilter) {
+        List(selection: $center.selectedSidebarSelection) {
             Section("Library") {
                 ForEach(DownloadFilter.allCases) { filter in
                     HStack(spacing: 10) {
@@ -15,7 +15,21 @@ struct SidebarView: View {
                         Text(center.count(for: filter), format: .number)
                             .foregroundStyle(.secondary)
                     }
-                    .tag(filter)
+                    .tag(DownloadSidebarSelection.filter(filter))
+                }
+            }
+
+            if center.availableTags.isEmpty == false {
+                Section("Tags") {
+                    ForEach(center.availableTags, id: \.self) { tag in
+                        HStack(spacing: 10) {
+                            Label(tag, systemImage: "tag")
+                            Spacer()
+                            Text(center.count(forTag: tag), format: .number)
+                                .foregroundStyle(.secondary)
+                        }
+                        .tag(DownloadSidebarSelection.tag(tag))
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add persisted manual tags to download records and add-download requests.
- Add tag filters in the sidebar without replacing existing status filters.
- Add tag entry in the Add Download sheet and add/remove editing in the detail inspector.
- Include tag names in download search and update previews with sample tags.

Closes #9

## Verification

- `xcodebuild -project Harbor.xcodeproj -scheme Harbor -configuration Debug -derivedDataPath /private/tmp/HarborDerivedData build`