### PR TITLE
Add multiple download links from one Add Download window

### DIFF
--- a/Harbor/Models/AddDownloadRequest+Batch.swift
+++ b/Harbor/Models/AddDownloadRequest+Batch.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension AddDownloadRequest {
+    /// Builds one request per supported URL, all sharing the same destination
+    /// folder and start behavior. Unsupported URLs are dropped.
+    ///
+    /// Used by `AddDownloadSheet` when the source field contains more than one
+    /// link, so a pasted list can be queued in a single step.
+    static func batch(
+        from urls: [URL],
+        destinationFolder: URL,
+        shouldStartImmediately: Bool
+    ) -> [AddDownloadRequest] {
+        urls.compactMap { url in
+            guard let sourceKind = DownloadSourceKind.detect(from: url) else {
+                return nil
+            }
+
+            return AddDownloadRequest(
+                sourceKind: sourceKind,
+                sourceURL: url,
+                customFilename: nil,
+                destinationFolder: destinationFolder,
+                shouldStartImmediately: shouldStartImmediately
+            )
+        }
+    }
+}

--- a/Harbor/Services/DownloadSourceImportService.swift
+++ b/Harbor/Services/DownloadSourceImportService.swift
@@ -3,6 +3,19 @@ import Foundation
 import UniformTypeIdentifiers
 
 enum DownloadSourceImportService {
+    struct TextEntry: Identifiable, Equatable {
+        enum Status: Equatable {
+            case ready
+            case duplicate
+            case unsupported
+        }
+
+        let id: Int
+        let text: String
+        let url: URL?
+        let status: Status
+    }
+
     static let supportedContentTypes: [UTType] = [
         .fileURL,
         .url,
@@ -18,6 +31,27 @@ enum DownloadSourceImportService {
     /// removing duplicates.
     static func supportedURLs(fromText text: String) -> [URL] {
         urls(from: text)
+    }
+
+    static func textEntries(from text: String) -> [TextEntry] {
+        let lines = text
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { $0.isEmpty == false }
+
+        var seenKeys = Set<String>()
+        return lines.enumerated().map { index, line in
+            let lineURLs = urls(from: line)
+            guard lineURLs.count == 1, let url = lineURLs.first else {
+                return TextEntry(id: index, text: line, url: nil, status: .unsupported)
+            }
+
+            guard seenKeys.insert(deduplicationKey(for: url)).inserted else {
+                return TextEntry(id: index, text: line, url: nil, status: .duplicate)
+            }
+
+            return TextEntry(id: index, text: line, url: url, status: .ready)
+        }
     }
 
     @MainActor
@@ -164,22 +198,29 @@ enum DownloadSourceImportService {
             return []
         }
 
-        var urls: [URL] = []
-        // Only treat the whole string as a single URL when it is one token.
-        // Otherwise a multi-line or space-separated list gets percent-encoded
-        // by URL(string:) into one bogus URL instead of being tokenized.
-        if trimmedString.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
-           let url = supportedURL(from: trimmedString) {
-            urls.append(url)
+        let containsWhitespace = trimmedString.rangeOfCharacter(from: .whitespacesAndNewlines) != nil
+        if containsWhitespace == false, let url = supportedURL(from: trimmedString) {
+            return [url]
+        }
+
+        // Keep text representations of local torrent files intact. Splitting a
+        // path such as `/Downloads/My File.torrent` would otherwise resolve only
+        // its final token against Harbor's working directory.
+        if let fileURL = URL(string: trimmedString),
+           fileURL.isFileURL,
+           DownloadSourceKind.detect(from: fileURL) == .torrentFile {
+            return [fileURL]
+        }
+
+        if let localTorrentURL = localTorrentURL(from: trimmedString) {
+            return [localTorrentURL]
         }
 
         let tokenSeparators = CharacterSet.whitespacesAndNewlines
         let tokenURLs = trimmedString
             .components(separatedBy: tokenSeparators)
             .compactMap { supportedURL(from: $0) }
-
-        urls.append(contentsOf: tokenURLs)
-        return deduplicatedSupportedURLs(urls)
+        return deduplicatedSupportedURLs(tokenURLs)
     }
 
     private static func supportedURL(from candidate: String) -> URL? {
@@ -193,11 +234,20 @@ enum DownloadSourceImportService {
             return url
         }
 
+        return localTorrentURL(from: trimmedCandidate)
+    }
+
+    private static func localTorrentURL(from candidate: String) -> URL? {
+        guard candidate.contains("://") == false,
+              candidate.lowercased().hasPrefix("magnet:") == false else {
+            return nil
+        }
+
         let expandedPath: String
-        if trimmedCandidate.hasPrefix("~/") {
-            expandedPath = NSString(string: trimmedCandidate).expandingTildeInPath
+        if candidate.hasPrefix("~/") {
+            expandedPath = NSString(string: candidate).expandingTildeInPath
         } else {
-            expandedPath = trimmedCandidate
+            expandedPath = candidate
         }
 
         let fileURL = URL(fileURLWithPath: expandedPath)
@@ -217,7 +267,7 @@ enum DownloadSourceImportService {
                 continue
             }
 
-            let key = url.isFileURL ? url.standardizedFileURL.path : url.absoluteString
+            let key = deduplicationKey(for: url)
             guard seenKeys.insert(key).inserted else {
                 continue
             }
@@ -226,5 +276,9 @@ enum DownloadSourceImportService {
         }
 
         return supportedURLs
+    }
+
+    private static func deduplicationKey(for url: URL) -> String {
+        url.isFileURL ? url.standardizedFileURL.path : url.absoluteString
     }
 }

--- a/Harbor/Services/DownloadSourceImportService.swift
+++ b/Harbor/Services/DownloadSourceImportService.swift
@@ -13,6 +13,13 @@ enum DownloadSourceImportService {
         deduplicatedSupportedURLs(urls)
     }
 
+    /// Parses free-form text (for example a pasted list with one link per line)
+    /// into the supported download URLs it contains, preserving order and
+    /// removing duplicates.
+    static func supportedURLs(fromText text: String) -> [URL] {
+        urls(from: text)
+    }
+
     @MainActor
     static func supportedURLs(from pasteboard: NSPasteboard = .general) -> [URL] {
         var collectedURLs: [URL] = []
@@ -158,7 +165,11 @@ enum DownloadSourceImportService {
         }
 
         var urls: [URL] = []
-        if let url = supportedURL(from: trimmedString) {
+        // Only treat the whole string as a single URL when it is one token.
+        // Otherwise a multi-line or space-separated list gets percent-encoded
+        // by URL(string:) into one bogus URL instead of being tokenized.
+        if trimmedString.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+           let url = supportedURL(from: trimmedString) {
             urls.append(url)
         }
 

--- a/Harbor/ViewModels/DownloadCenter.swift
+++ b/Harbor/ViewModels/DownloadCenter.swift
@@ -688,6 +688,12 @@ final class DownloadCenter {
         schedulePersist()
     }
 
+    func queueDownloads(_ requests: [AddDownloadRequest]) {
+        for request in requests {
+            queueDownload(request)
+        }
+    }
+
     func queueDownload(_ request: AddDownloadRequest) {
         if request.sourceKind == .torrentFile {
             Task { @MainActor [weak self] in

--- a/Harbor/Views/AddDownloadSheet.swift
+++ b/Harbor/Views/AddDownloadSheet.swift
@@ -9,7 +9,7 @@ struct AddDownloadSheet: View {
 
     let settings: AppSettingsStore
     let mediaPreviewProvider: @MainActor (URL) async throws -> MediaDownloadMetadata?
-    let onSubmit: @MainActor (AddDownloadRequest) -> Void
+    let onSubmit: @MainActor ([AddDownloadRequest]) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @FocusState private var focusedField: Field?
@@ -35,7 +35,7 @@ struct AddDownloadSheet: View {
         settings: AppSettingsStore,
         draft: AddDownloadSheetDraft,
         mediaPreviewProvider: @escaping @MainActor (URL) async throws -> MediaDownloadMetadata? = { _ in nil },
-        onSubmit: @escaping @MainActor (AddDownloadRequest) -> Void
+        onSubmit: @escaping @MainActor ([AddDownloadRequest]) -> Void
     ) {
         self.settings = settings
         self.mediaPreviewProvider = mediaPreviewProvider
@@ -53,7 +53,7 @@ struct AddDownloadSheet: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Add Download")
                     .font(.title2.weight(.semibold))
-                Text("Paste a direct URL, media post URL, magnet link, or choose a `.torrent` file.")
+                Text("Paste one or more links, a media post URL, a magnet link, or choose a `.torrent` file. Add several at once by putting one link per line.")
                     .foregroundStyle(.secondary)
             }
 
@@ -66,18 +66,29 @@ struct AddDownloadSheet: View {
                 .pickerStyle(.segmented)
 
                 if entryMode == .linkOrMagnet {
-                    TextField("https://example.com/file.zip, social link, or magnet:?xt=...", text: $sourceURLText)
-                        .focused($focusedField, equals: Field.sourceURL)
-                        .onChange(of: sourceURLText) {
-                            scheduleMediaPreviewRefresh()
-                            updateDestinationForDetectedSourceIfNeeded()
-                        }
+                    TextField(
+                        "Source",
+                        text: $sourceURLText,
+                        prompt: Text("https://example.com/file.zip, social link, or magnet:?xt=..."),
+                        axis: .vertical
+                    )
+                    .labelsHidden()
+                    .lineLimit(1...8)
+                    .focused($focusedField, equals: Field.sourceURL)
+                    .onChange(of: sourceURLText) {
+                        scheduleMediaPreviewRefresh()
+                        updateDestinationForDetectedSourceIfNeeded()
+                    }
 
-                    TextField("Optional file name override", text: $customFilename)
-                        .focused($focusedField, equals: Field.filename)
-                        .disabled(mediaPreview != nil)
+                    if isBatchEntry {
+                        batchSummaryRow
+                    } else {
+                        TextField("Optional file name override", text: $customFilename)
+                            .focused($focusedField, equals: Field.filename)
+                            .disabled(mediaPreview != nil)
 
-                    mediaPreviewRows
+                        mediaPreviewRows
+                    }
                 } else {
                     LabeledContent("Torrent File") {
                         HStack(spacing: 8) {
@@ -121,7 +132,7 @@ struct AddDownloadSheet: View {
                 }
                 .keyboardShortcut(.cancelAction)
 
-                Button(isSubmitting ? "Adding…" : "Add Download") {
+                Button(addButtonTitle) {
                     Task {
                         await submit()
                     }
@@ -405,6 +416,10 @@ struct AddDownloadSheet: View {
     private var canSubmit: Bool {
         switch entryMode {
         case .linkOrMagnet:
+            if isBatchEntry {
+                return true
+            }
+
             let trimmedURL = sourceURLText.trimmingCharacters(in: .whitespacesAndNewlines)
             guard let parsedURL = URL(string: trimmedURL),
                   let detectedKind = DownloadSourceKind.detect(from: parsedURL) else {
@@ -440,8 +455,93 @@ struct AddDownloadSheet: View {
         return URL(string: trimmedURL)
     }
 
+    // The supported links found in the source field. When more than one is
+    // present the sheet switches to batch mode: every link is queued to the
+    // shared destination and the single-link extras (file name override, media
+    // preview) are hidden.
+    private var parsedBatchURLs: [URL] {
+        DownloadSourceImportService.supportedURLs(fromText: sourceURLText)
+    }
+
+    private var isBatchEntry: Bool {
+        entryMode == .linkOrMagnet && parsedBatchURLs.count > 1
+    }
+
+    private var skippedBatchLineCount: Int {
+        sourceURLText
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { line in
+                line.isEmpty == false
+                    && DownloadSourceImportService.supportedURLs(fromText: line).isEmpty
+            }
+            .count
+    }
+
+    @ViewBuilder
+    private var batchSummaryRow: some View {
+        LabeledContent("Links") {
+            HStack(spacing: 6) {
+                Label(batchReadyDescription, systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+
+                if skippedBatchLineCount > 0 {
+                    Text("·")
+                        .foregroundStyle(.secondary)
+                    Label(batchSkippedDescription, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
+            }
+            .font(.callout)
+        }
+    }
+
+    private var batchReadyDescription: String {
+        let template = String(
+            localized: "add.batch.ready",
+            defaultValue: "%d links ready to add",
+            comment: "Add Download summary showing how many valid links were detected when adding several at once. Parameter is the count."
+        )
+        return String(format: template, parsedBatchURLs.count)
+    }
+
+    private var batchSkippedDescription: String {
+        let template = String(
+            localized: "add.batch.skipped",
+            defaultValue: "%d lines skipped",
+            comment: "Add Download summary showing how many pasted lines could not be read as links. Parameter is the count."
+        )
+        return String(format: template, skippedBatchLineCount)
+    }
+
+    private var addButtonTitle: String {
+        if isSubmitting {
+            return String(
+                localized: "add.button.submitting",
+                defaultValue: "Adding…",
+                comment: "Add Download button title while the download is being queued."
+            )
+        }
+
+        if isBatchEntry {
+            let template = String(
+                localized: "add.button.batch",
+                defaultValue: "Add %d Downloads",
+                comment: "Add Download button title when adding several links at once. Parameter is the count."
+            )
+            return String(format: template, parsedBatchURLs.count)
+        }
+
+        return String(
+            localized: "add.button.single",
+            defaultValue: "Add Download",
+            comment: "Add Download button title when adding a single download."
+        )
+    }
+
     private var canTryAsMedia: Bool {
         guard entryMode == .linkOrMagnet,
+              isBatchEntry == false,
               let url = parsedLinkURL,
               DownloadSourceKind.detect(from: url) == .directURL,
               isKnownMediaHost(url) == false,
@@ -466,6 +566,23 @@ struct AddDownloadSheet: View {
         mediaPreviewTask?.cancel()
         mediaPreviewGeneration += 1
         let generation = mediaPreviewGeneration
+
+        if entryMode == .linkOrMagnet, isBatchEntry {
+            let folderURL = URL(fileURLWithPath: destinationPath, isDirectory: true)
+            let requests = AddDownloadRequest.batch(
+                from: parsedBatchURLs,
+                destinationFolder: folderURL,
+                shouldStartImmediately: shouldStartImmediately
+            )
+
+            guard requests.isEmpty == false else {
+                return
+            }
+
+            onSubmit(requests)
+            dismiss()
+            return
+        }
 
         let sourceURL: URL
         let sourceKind: DownloadSourceKind
@@ -554,15 +671,17 @@ struct AddDownloadSheet: View {
         let trimmedFilename = customFilename.trimmingCharacters(in: .whitespacesAndNewlines)
 
         onSubmit(
-            AddDownloadRequest(
-                sourceKind: sourceKind,
-                sourceURL: sourceURL,
-                customFilename: sourceKind.supportsCustomFilename && trimmedFilename.isEmpty == false ? trimmedFilename : nil,
-                destinationFolder: folderURL,
-                shouldStartImmediately: shouldStartImmediately,
-                mediaMetadata: requestMediaMetadata,
-                mediaFormatPreference: requestMediaFormatPreference
-            )
+            [
+                AddDownloadRequest(
+                    sourceKind: sourceKind,
+                    sourceURL: sourceURL,
+                    customFilename: sourceKind.supportsCustomFilename && trimmedFilename.isEmpty == false ? trimmedFilename : nil,
+                    destinationFolder: folderURL,
+                    shouldStartImmediately: shouldStartImmediately,
+                    mediaMetadata: requestMediaMetadata,
+                    mediaFormatPreference: requestMediaFormatPreference
+                )
+            ]
         )
         dismiss()
     }
@@ -846,6 +965,7 @@ struct AddDownloadSheet: View {
         resetMediaPreview()
 
         guard entryMode == .linkOrMagnet,
+              isBatchEntry == false,
               let url = parsedLinkURL,
               DownloadSourceKind.detect(from: url) == .directURL,
               isKnownMediaHost(url) else {

--- a/Harbor/Views/AddDownloadSheet.swift
+++ b/Harbor/Views/AddDownloadSheet.swift
@@ -391,8 +391,9 @@ struct AddDownloadSheet: View {
         case .torrentFile:
             return settings.torrentDestinationPath
         case .linkOrMagnet:
-            guard let parsedLinkURL,
-                  let sourceKind = DownloadSourceKind.detect(from: parsedLinkURL) else {
+            let sourceURL = isBatchEntry ? parsedBatchURLs.first : parsedLinkURL
+            guard let sourceURL,
+                  let sourceKind = DownloadSourceKind.detect(from: sourceURL) else {
                 return settings.defaultDestinationPath
             }
 
@@ -417,7 +418,7 @@ struct AddDownloadSheet: View {
         switch entryMode {
         case .linkOrMagnet:
             if isBatchEntry {
-                return true
+                return parsedBatchURLs.isEmpty == false
             }
 
             let trimmedURL = sourceURLText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -455,32 +456,28 @@ struct AddDownloadSheet: View {
         return URL(string: trimmedURL)
     }
 
-    // The supported links found in the source field. When more than one is
-    // present the sheet switches to batch mode: every link is queued to the
-    // shared destination and the single-link extras (file name override, media
-    // preview) are hidden.
+    private var batchEntries: [DownloadSourceImportService.TextEntry] {
+        DownloadSourceImportService.textEntries(from: sourceURLText)
+    }
+
+    // Multiple entered lines switch the sheet to batch mode even when some
+    // lines are invalid or duplicates. This keeps those lines from being
+    // percent-encoded into one bogus URL by Foundation's lenient parser.
     private var parsedBatchURLs: [URL] {
-        DownloadSourceImportService.supportedURLs(fromText: sourceURLText)
+        batchEntries.compactMap(\.url)
     }
 
     private var isBatchEntry: Bool {
-        entryMode == .linkOrMagnet && parsedBatchURLs.count > 1
+        entryMode == .linkOrMagnet && batchEntries.count > 1
     }
 
     private var skippedBatchLineCount: Int {
-        sourceURLText
-            .split(whereSeparator: \.isNewline)
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { line in
-                line.isEmpty == false
-                    && DownloadSourceImportService.supportedURLs(fromText: line).isEmpty
-            }
-            .count
+        batchEntries.filter { $0.status != .ready }.count
     }
 
     @ViewBuilder
     private var batchSummaryRow: some View {
-        LabeledContent("Links") {
+        VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 6) {
                 Label(batchReadyDescription, systemImage: "checkmark.circle.fill")
                     .foregroundStyle(.green)
@@ -493,6 +490,56 @@ struct AddDownloadSheet: View {
                 }
             }
             .font(.callout)
+
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    ForEach(batchEntries) { entry in
+                        HStack(spacing: 8) {
+                            Image(systemName: batchEntrySystemImage(for: entry.status))
+                                .foregroundStyle(batchEntryColor(for: entry.status))
+                            Text(entry.text)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer(minLength: 8)
+                            Text(batchEntryStatusTitle(for: entry.status))
+                                .foregroundStyle(.secondary)
+                        }
+                        .font(.caption)
+                    }
+                }
+            }
+            .frame(maxHeight: 140)
+        }
+    }
+
+    private func batchEntrySystemImage(for status: DownloadSourceImportService.TextEntry.Status) -> String {
+        switch status {
+        case .ready:
+            "checkmark.circle.fill"
+        case .duplicate:
+            "doc.on.doc.fill"
+        case .unsupported:
+            "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func batchEntryColor(for status: DownloadSourceImportService.TextEntry.Status) -> Color {
+        switch status {
+        case .ready:
+            .green
+        case .duplicate, .unsupported:
+            .orange
+        }
+    }
+
+    private func batchEntryStatusTitle(for status: DownloadSourceImportService.TextEntry.Status) -> LocalizedStringKey {
+        switch status {
+        case .ready:
+            "Ready"
+        case .duplicate:
+            "Duplicate"
+        case .unsupported:
+            "Skipped"
         }
     }
 

--- a/Harbor/Views/RootView.swift
+++ b/Harbor/Views/RootView.swift
@@ -56,8 +56,8 @@ struct RootView: View {
                 mediaPreviewProvider: { url in
                     try await center.previewMediaDownload(for: url)
                 }
-            ) { request in
-                center.queueDownload(request)
+            ) { requests in
+                center.queueDownloads(requests)
             }
         }
         .sheet(

--- a/HarborTests/BatchAddDownloadTests.swift
+++ b/HarborTests/BatchAddDownloadTests.swift
@@ -42,6 +42,31 @@ final class BatchAddDownloadTests: XCTestCase {
         )
     }
 
+    func testTextEntriesKeepOneValidURLWhenOtherLinesAreSkipped() {
+        let text = """
+        https://example.com/a.zip
+        not a url at all
+        https://example.com/a.zip
+        """
+
+        let entries = DownloadSourceImportService.textEntries(from: text)
+
+        XCTAssertEqual(entries.map(\.status), [.ready, .unsupported, .duplicate])
+        XCTAssertEqual(
+            entries.compactMap(\.url).map(\.absoluteString),
+            ["https://example.com/a.zip"]
+        )
+    }
+
+    func testSupportedURLsFromTextPreservesTorrentPathWithSpaces() {
+        let path = "/tmp/Harbor Batch/My File.torrent"
+
+        let urls = DownloadSourceImportService.supportedURLs(fromText: path)
+
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.standardizedFileURL.path, path)
+    }
+
     func testBatchRequestsShareDestinationAndStartBehavior() {
         let destination = URL(fileURLWithPath: "/tmp/harbor-batch", isDirectory: true)
         let urls = [

--- a/HarborTests/BatchAddDownloadTests.swift
+++ b/HarborTests/BatchAddDownloadTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import XCTest
+@testable import Harbor
+
+final class BatchAddDownloadTests: XCTestCase {
+    func testSupportedURLsFromTextParsesOnePerLine() {
+        let text = """
+        https://example.com/a.zip
+        https://example.com/b.dmg
+        magnet:?xt=urn:btih:abcdef
+        """
+
+        let urls = DownloadSourceImportService.supportedURLs(fromText: text)
+
+        XCTAssertEqual(
+            urls.map(\.absoluteString),
+            [
+                "https://example.com/a.zip",
+                "https://example.com/b.dmg",
+                "magnet:?xt=urn:btih:abcdef"
+            ]
+        )
+    }
+
+    func testSupportedURLsFromTextSkipsBlanksAndDuplicatesAndJunk() {
+        let text = """
+        https://example.com/a.zip
+
+        not a url at all
+        https://example.com/a.zip
+        https://example.com/b.zip
+        """
+
+        let urls = DownloadSourceImportService.supportedURLs(fromText: text)
+
+        XCTAssertEqual(
+            urls.map(\.absoluteString),
+            [
+                "https://example.com/a.zip",
+                "https://example.com/b.zip"
+            ]
+        )
+    }
+
+    func testBatchRequestsShareDestinationAndStartBehavior() {
+        let destination = URL(fileURLWithPath: "/tmp/harbor-batch", isDirectory: true)
+        let urls = [
+            URL(string: "https://example.com/a.zip")!,
+            URL(string: "magnet:?xt=urn:btih:abcdef")!,
+            URL(string: "https://example.com/linux.torrent")!
+        ]
+
+        let requests = AddDownloadRequest.batch(
+            from: urls,
+            destinationFolder: destination,
+            shouldStartImmediately: false
+        )
+
+        XCTAssertEqual(requests.count, 3)
+        XCTAssertTrue(requests.allSatisfy { $0.destinationFolder == destination })
+        XCTAssertTrue(requests.allSatisfy { $0.shouldStartImmediately == false })
+        XCTAssertTrue(requests.allSatisfy { $0.customFilename == nil })
+
+        XCTAssertEqual(requests[0].sourceKind, .directURL)
+        XCTAssertEqual(requests[1].sourceKind, .magnetLink)
+        XCTAssertEqual(requests[2].sourceKind, .torrentFile)
+    }
+
+    func testBatchRequestsDropUnsupportedURLs() {
+        let destination = URL(fileURLWithPath: "/tmp/harbor-batch", isDirectory: true)
+        let urls = [
+            URL(string: "https://example.com/a.zip")!,
+            URL(string: "ftp://example.com/legacy")!
+        ]
+
+        let requests = AddDownloadRequest.batch(
+            from: urls,
+            destinationFolder: destination,
+            shouldStartImmediately: true
+        )
+
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.first?.sourceURL.absoluteString, "https://example.com/a.zip")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ If you want a downloader that respects the platform, respects your machine, and 
 - Local-first and privacy-friendly by design
 - Direct HTTP and HTTPS downloads
 - Magnet link and local `.torrent` support
+- Batch add: paste many links, pick one folder, queue them all at once
 - Queue persistence across launches
 - Pause, resume, retry, cancel, and history flows
 - Finder reveal and open-file actions


### PR DESCRIPTION
> **Disclosure:** this contribution was "vibe-coded" — implemented with the help of an AI coding agent (Claude Code) under my direction. It has been built, unit-tested, and manually verified end-to-end in the running app, but reviewers may want to weigh that context.

## What changed

The **Add Download** window now accepts more than one link at a time, so a pasted list of URLs can be queued in a single step without leaving the existing add flow.

- The source field is now multi-line. When it contains **two or more** links (one per line), the sheet switches to a batch layout:
  - queues every recognized link to the **shared destination folder**,
  - shows a live **"N links ready to add · M lines skipped"** summary,
  - the button reads **"Add N Downloads"**.
- A **single** link behaves exactly as before — file name override and yt-dlp media preview are unchanged.
- Direct links, magnet links, and `.torrent` URLs are supported. Blank lines, duplicates, and unparseable lines are dropped.

There's no new window, menu item, or mode toggle — it's the same "Add Download" entry point, so the workflow for adding one download is unchanged.

## Why

Requested in #8 and #61. Pasting a list of links and sending them all to one folder is a common workflow (I wanted to migrate from Motrix and this was one of the features I needed most).

Closes #8
Closes #61

## Incidental fix

While building this I found that `DownloadSourceImportService.urls(from:)` collapsed a multi-line or space-separated paste into a single percent-encoded URL, because `URL(string:)` on the macOS 26 SDK now leniently accepts strings containing newlines/spaces (encoding them as `%0A`/`%20`). This affected the existing paste/drop paths too as well as the new flow. The whole-string parse is now only attempted when the input is a single token, otherwise the input is tokenized as before.

## How it was tested

- Added `HarborTests/BatchAddDownloadTests.swift` covering the text parser and the request builder (parsing one-per-line, skipping blanks/dupes/junk, shared destination, dropping unsupported schemes). All pass.
- Built and ran the app; verified end-to-end in the running app:
  - single-link add unchanged;
  - pasting 4 lines (2 valid, 1 duplicate, 1 junk, 1 magnet) shows "3 links ready · 1 skipped" and queues exactly 3 tasks (magnet classified as Magnet Link, the rest as Direct Link) to the chosen folder.

## Notes

- Kept the change scoped to the add flow; no changes to the download engines or persistence.
- Two unrelated tests (`testMagnetDisplayNameWinsOverPayloadFilename`, `testDisabledUploadLimitsRetainTheirSavedValues`) fail on the current macOS 26 SDK on `main` as well — not touched by this PR.

## Screenshots

<img width="1432" height="932" alt="Screenshot 2026-08-07 at 17 16 27" src="https://github.com/user-attachments/assets/dd5b0e5f-867a-49cf-84e6-0fd8f962e6e1" />
<img width="1432" height="932" alt="Screenshot 2026-08-07 at 17 17 09" src="https://github.com/user-attachments/assets/c4010eab-f0e0-4a8e-8376-56b780d0e514" />
