### PR TITLE
Bind torrent traffic to a network interface

### DIFF
--- a/Harbor/Models/NetworkBinding.swift
+++ b/Harbor/Models/NetworkBinding.swift
@@ -51,8 +51,22 @@ nonisolated struct NetworkBindingTarget: Identifiable, Equatable, Sendable {
     let selection: NetworkBindingSelection
     let displayName: String
     let kind: NetworkBindingTargetKind
+    /// Tells a VPN apart from an ordinary connection at a glance.
+    let symbolName: String
 
     var id: String { selection.storageValue }
+
+    init(
+        selection: NetworkBindingSelection,
+        displayName: String,
+        kind: NetworkBindingTargetKind,
+        symbolName: String = "network"
+    ) {
+        self.selection = selection
+        self.displayName = displayName
+        self.kind = kind
+        self.symbolName = symbolName
+    }
 
     static let any = NetworkBindingTarget(
         selection: .any,
@@ -61,7 +75,8 @@ nonisolated struct NetworkBindingTarget: Identifiable, Equatable, Sendable {
             defaultValue: "Any Interface",
             comment: "Torrent network binding option that applies no interface restriction."
         ),
-        kind: .any
+        kind: .any,
+        symbolName: "circle.dashed"
     )
 }
 

--- a/Harbor/Models/NetworkBinding.swift
+++ b/Harbor/Models/NetworkBinding.swift
@@ -47,25 +47,55 @@ nonisolated enum NetworkBindingTargetKind: Equatable, Sendable {
     case interface
 }
 
+/// What a target carries its traffic over. The case order is the order the
+/// picker groups by: a VPN is the reason this setting exists, so it leads.
+nonisolated enum NetworkBindingMedium: Int, Comparable, Sendable {
+    case vpn
+    case wireless
+    case wired
+    case other
+
+    var symbolName: String {
+        switch self {
+        case .vpn:
+            "lock.shield"
+        case .wireless:
+            "wifi"
+        case .wired:
+            "cable.connector"
+        case .other:
+            "network"
+        }
+    }
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
 nonisolated struct NetworkBindingTarget: Identifiable, Equatable, Sendable {
     let selection: NetworkBindingSelection
     let displayName: String
     let kind: NetworkBindingTargetKind
-    /// Tells a VPN apart from an ordinary connection at a glance.
-    let symbolName: String
+    let medium: NetworkBindingMedium
 
     var id: String { selection.storageValue }
+
+    /// Tells a VPN apart from an ordinary connection at a glance.
+    var symbolName: String {
+        kind == .any ? "circle.dashed" : medium.symbolName
+    }
 
     init(
         selection: NetworkBindingSelection,
         displayName: String,
         kind: NetworkBindingTargetKind,
-        symbolName: String = "network"
+        medium: NetworkBindingMedium = .other
     ) {
         self.selection = selection
         self.displayName = displayName
         self.kind = kind
-        self.symbolName = symbolName
+        self.medium = medium
     }
 
     static let any = NetworkBindingTarget(
@@ -75,9 +105,19 @@ nonisolated struct NetworkBindingTarget: Identifiable, Equatable, Sendable {
             defaultValue: "Automatic",
             comment: "Torrent network binding option that applies no interface restriction."
         ),
-        kind: .any,
-        symbolName: "circle.dashed"
+        kind: .any
     )
+
+    /// Groups entries by what they run over and sorts each group the way the
+    /// Finder sorts names, so `en2` stays ahead of `en10`.
+    static func sortedByMedium(_ targets: [NetworkBindingTarget]) -> [NetworkBindingTarget] {
+        targets.sorted { lhs, rhs in
+            guard lhs.medium == rhs.medium else {
+                return lhs.medium < rhs.medium
+            }
+            return lhs.displayName.localizedStandardCompare(rhs.displayName) == .orderedAscending
+        }
+    }
 }
 
 /// The interface a selection currently points at.

--- a/Harbor/Models/NetworkBinding.swift
+++ b/Harbor/Models/NetworkBinding.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Which network path Harbor binds torrent traffic to.
+///
+/// A service is stored by its SystemConfiguration identifier because a VPN
+/// service such as ProtonVPN has no fixed BSD interface: it appears as a
+/// different `utunN` on every connection.
+nonisolated enum NetworkBindingSelection: Hashable, Sendable {
+    case any
+    case service(id: String)
+    case interface(name: String)
+
+    private enum Prefix {
+        static let service = "service:"
+        static let interface = "interface:"
+    }
+
+    /// The `UserDefaults` representation. `.any` is stored as an empty string so
+    /// an absent preference and an explicit "Any Interface" agree.
+    var storageValue: String {
+        switch self {
+        case .any:
+            ""
+        case let .service(id):
+            Prefix.service + id
+        case let .interface(name):
+            Prefix.interface + name
+        }
+    }
+
+    init(storageValue: String) {
+        if storageValue.hasPrefix(Prefix.service) {
+            let id = String(storageValue.dropFirst(Prefix.service.count))
+            self = id.isEmpty ? .any : .service(id: id)
+        } else if storageValue.hasPrefix(Prefix.interface) {
+            let name = String(storageValue.dropFirst(Prefix.interface.count))
+            self = name.isEmpty ? .any : .interface(name: name)
+        } else {
+            self = .any
+        }
+    }
+}
+
+nonisolated enum NetworkBindingTargetKind: Equatable, Sendable {
+    case any
+    case service
+    case interface
+}
+
+nonisolated struct NetworkBindingTarget: Identifiable, Equatable, Sendable {
+    let selection: NetworkBindingSelection
+    let displayName: String
+    let kind: NetworkBindingTargetKind
+
+    var id: String { selection.storageValue }
+
+    static let any = NetworkBindingTarget(
+        selection: .any,
+        displayName: String(
+            localized: "network.binding.any",
+            defaultValue: "Any Interface",
+            comment: "Torrent network binding option that applies no interface restriction."
+        ),
+        kind: .any
+    )
+}
+
+/// The interface a selection currently points at.
+///
+/// aria2 resolves `--interface` to an address once at startup and caches it, so
+/// a changed address matters as much as a changed interface name: both require
+/// a daemon restart.
+nonisolated struct ResolvedNetworkBinding: Equatable, Sendable {
+    let interfaceName: String
+    let ipv4Address: String?
+}
+
+nonisolated enum NetworkBindingStatus: Equatable, Sendable {
+    case unrestricted
+    case bound(displayName: String, binding: ResolvedNetworkBinding)
+    case unavailable(displayName: String)
+}

--- a/Harbor/Models/NetworkBinding.swift
+++ b/Harbor/Models/NetworkBinding.swift
@@ -16,7 +16,7 @@ nonisolated enum NetworkBindingSelection: Hashable, Sendable {
     }
 
     /// The `UserDefaults` representation. `.any` is stored as an empty string so
-    /// an absent preference and an explicit "Any Interface" agree.
+    /// an absent preference and an explicit "Automatic" agree.
     var storageValue: String {
         switch self {
         case .any:
@@ -72,7 +72,7 @@ nonisolated struct NetworkBindingTarget: Identifiable, Equatable, Sendable {
         selection: .any,
         displayName: String(
             localized: "network.binding.any",
-            defaultValue: "Any Interface",
+            defaultValue: "Automatic",
             comment: "Torrent network binding option that applies no interface restriction."
         ),
         kind: .any,

--- a/Harbor/Services/AppSettingsStore.swift
+++ b/Harbor/Services/AppSettingsStore.swift
@@ -553,7 +553,7 @@ final class AppSettingsStore {
     }
 
     /// Keeps a selection that has disappeared, such as a removed VPN service,
-    /// visible in the picker instead of silently reverting to "Any Interface".
+    /// visible in the picker instead of silently reverting to "Automatic".
     var networkBindingPickerTargets: [NetworkBindingTarget] {
         var targets = availableNetworkBindingTargets
         guard targets.contains(where: { $0.selection == networkBindingSelection }) == false else {

--- a/Harbor/Services/AppSettingsStore.swift
+++ b/Harbor/Services/AppSettingsStore.swift
@@ -93,6 +93,8 @@ final class AppSettingsStore {
         static let perDownloadUploadSpeedLimitEnabled = "perDownloadUploadSpeedLimitEnabled"
         static let perDownloadUploadSpeedLimitKilobytesPerSecond = "perDownloadUploadSpeedLimitKilobytesPerSecond"
         static let perDownloadConnectionCount = "perDownloadConnectionCount"
+        static let networkBindingSelection = "torrentNetworkBindingSelection"
+        static let networkBindingDisplayName = "torrentNetworkBindingDisplayName"
     }
 
     static let maxConcurrentDownloadsRange = 1 ... 16
@@ -102,8 +104,10 @@ final class AppSettingsStore {
 
     private let userDefaults: UserDefaults
     @ObservationIgnored private let loginItemController: any LoginItemControlling
+    @ObservationIgnored private let networkBindingCatalog: any NetworkBindingCataloging
     @ObservationIgnored var transferSettingsDidChange: ((DownloadTransferSettings) -> Void)?
     @ObservationIgnored var torrentAutomationSettingsDidChange: (() -> Void)?
+    @ObservationIgnored var networkBindingDidChange: ((NetworkBindingSelection) -> Void)?
 
     var defaultDestinationPath: String {
         didSet {
@@ -154,6 +158,29 @@ final class AppSettingsStore {
     }
 
     private(set) var torrentWatchFolderStatus: TorrentWatchFolderStatus = .stopped
+
+    var networkBindingSelection: NetworkBindingSelection {
+        didSet {
+            userDefaults.set(
+                networkBindingSelection.storageValue,
+                forKey: Keys.networkBindingSelection
+            )
+            rememberNetworkBindingDisplayName()
+            networkBindingDidChange?(networkBindingSelection)
+        }
+    }
+
+    private(set) var availableNetworkBindingTargets: [NetworkBindingTarget] = [.any]
+    private(set) var networkBindingStatus: NetworkBindingStatus = .unrestricted
+
+    private var storedNetworkBindingDisplayName: String {
+        didSet {
+            userDefaults.set(
+                storedNetworkBindingDisplayName,
+                forKey: Keys.networkBindingDisplayName
+            )
+        }
+    }
 
     var maxConcurrentDownloads: Int {
         didSet {
@@ -277,11 +304,13 @@ final class AppSettingsStore {
 
     init(
         userDefaults: UserDefaults = .standard,
-        loginItemController: (any LoginItemControlling)? = nil
+        loginItemController: (any LoginItemControlling)? = nil,
+        networkBindingCatalog: (any NetworkBindingCataloging)? = nil
     ) {
         self.userDefaults = userDefaults
         let resolvedLoginItemController = loginItemController ?? SystemLoginItemController()
         self.loginItemController = resolvedLoginItemController
+        self.networkBindingCatalog = networkBindingCatalog ?? SystemNetworkBindingCatalog()
 
         let defaultDownloadsPath = FileManager.default.urls(
             for: .downloadsDirectory,
@@ -376,6 +405,16 @@ final class AppSettingsStore {
             storedConnectionCount == 0 ? 4 : storedConnectionCount,
             to: Self.perDownloadConnectionCountRange
         )
+
+        let storedSelection = NetworkBindingSelection(
+            storageValue: userDefaults.string(forKey: Keys.networkBindingSelection) ?? ""
+        )
+        self.networkBindingSelection = storedSelection
+        self.storedNetworkBindingDisplayName = userDefaults
+            .string(forKey: Keys.networkBindingDisplayName)
+            ?? Self.fallbackDisplayName(for: storedSelection)
+
+        refreshNetworkBindingTargets()
     }
 
     func refreshStartAtLoginStatus() {
@@ -493,6 +532,74 @@ final class AppSettingsStore {
 
     func updateTorrentWatchFolderStatus(_ status: TorrentWatchFolderStatus) {
         torrentWatchFolderStatus = status
+    }
+
+    func updateNetworkBindingStatus(_ status: NetworkBindingStatus) {
+        networkBindingStatus = status
+    }
+
+    func refreshNetworkBindingTargets() {
+        availableNetworkBindingTargets = networkBindingCatalog.availableTargets()
+        rememberNetworkBindingDisplayName()
+    }
+
+    /// The name to show for the current selection, falling back to the name it
+    /// carried the last time it existed.
+    var networkBindingDisplayName: String {
+        availableNetworkBindingTargets
+            .first { $0.selection == networkBindingSelection }?
+            .displayName
+            ?? storedNetworkBindingDisplayName
+    }
+
+    /// Keeps a selection that has disappeared, such as a removed VPN service,
+    /// visible in the picker instead of silently reverting to "Any Interface".
+    var networkBindingPickerTargets: [NetworkBindingTarget] {
+        var targets = availableNetworkBindingTargets
+        guard targets.contains(where: { $0.selection == networkBindingSelection }) == false else {
+            return targets
+        }
+
+        targets.append(
+            NetworkBindingTarget(
+                selection: networkBindingSelection,
+                displayName: String(
+                    format: String(
+                        localized: "network.binding.missingTarget",
+                        defaultValue: "%@ (unavailable)",
+                        comment: "Picker label for a stored network selection that no longer exists."
+                    ),
+                    networkBindingDisplayName
+                ),
+                kind: .service
+            )
+        )
+        return targets
+    }
+
+    private func rememberNetworkBindingDisplayName() {
+        guard let displayName = availableNetworkBindingTargets
+            .first(where: { $0.selection == networkBindingSelection })?
+            .displayName else {
+            return
+        }
+
+        storedNetworkBindingDisplayName = displayName
+    }
+
+    private static func fallbackDisplayName(for selection: NetworkBindingSelection) -> String {
+        switch selection {
+        case .any:
+            NetworkBindingTarget.any.displayName
+        case let .interface(name):
+            name
+        case .service:
+            String(
+                localized: "network.binding.unknownService",
+                defaultValue: "Unknown network",
+                comment: "Placeholder for a stored VPN or network service Harbor can no longer find."
+            )
+        }
     }
 
     private func notifyTransferSettingsChanged() {

--- a/Harbor/Services/Aria2TorrentService.swift
+++ b/Harbor/Services/Aria2TorrentService.swift
@@ -8,6 +8,7 @@ enum TorrentEngineError: LocalizedError {
     case invalidSource
     case invalidResponse
     case rpc(String)
+    case networkInterfaceUnavailable(String)
 
     var errorDescription: String? {
         switch self {
@@ -21,6 +22,12 @@ enum TorrentEngineError: LocalizedError {
             "The torrent engine returned an invalid response."
         case let .rpc(message):
             message
+        case let .networkInterfaceUnavailable(displayName):
+            """
+            Harbor can’t transfer torrents because the network \(displayName) \
+            isn’t available. Reconnect it, or choose a different network \
+            interface in Settings › Torrents.
+            """
         }
     }
 }
@@ -285,6 +292,7 @@ actor Aria2TorrentService {
     private let daemonStartupOperation: DaemonStartupOperation
     private let startupLogBuffer = TorrentEngineLogBuffer()
     private var transferSettings: DownloadTransferSettings
+    private var networkBinding: NetworkBindingStatus = .unrestricted
     private var isRetryingAfterSessionRecovery = false
 
     init(
@@ -311,6 +319,24 @@ actor Aria2TorrentService {
 
     func resolvedBinaryPath() -> String? {
         Aria2BinaryResolver.resolveBinaryURL()?.path
+    }
+
+    /// aria2 fixes `--interface` at launch and caches the address it resolves
+    /// to, so a changed binding can only be applied by restarting the daemon.
+    func setNetworkBinding(_ networkBinding: NetworkBindingStatus) async {
+        guard self.networkBinding != networkBinding else {
+            return
+        }
+        self.networkBinding = networkBinding
+
+        guard let process, process.isRunning else {
+            return
+        }
+
+        // Persist first so the restart, or the refusal to restart while the
+        // interface is gone, keeps every torrent recoverable.
+        try? await saveSession()
+        resetDaemon(terminateIfRunning: true)
     }
 
     func updateTransferSettings(
@@ -917,6 +943,11 @@ actor Aria2TorrentService {
     }
 
     private func startDaemonUntilReady() async throws {
+        // aria2 exits immediately when --interface names a missing interface.
+        // Refusing here turns that into an explanation the user can act on.
+        if case let .unavailable(displayName) = networkBinding {
+            throw TorrentEngineError.networkInterfaceUnavailable(displayName)
+        }
 
         if process != nil || rpcPort != nil || rpcSecret != nil || stderrPipe != nil {
             resetDaemon(terminateIfRunning: process?.isRunning == true)
@@ -935,39 +966,14 @@ actor Aria2TorrentService {
 
         let port = Int.random(in: 18_000 ... 28_000)
         let secret = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-        var arguments = [
-            "--enable-rpc=true",
-            "--rpc-listen-all=false",
-            "--rpc-listen-port=\(port)",
-            "--rpc-secret=\(secret)",
-            "--input-file=\(sessionFileURL.path)",
-            "--save-session=\(sessionFileURL.path)",
-            "--save-session-interval=5",
-            "--force-save=true",
-            "--stop-with-process=\(ProcessInfo.processInfo.processIdentifier)",
-            "--bt-detach-seed-only=true",
-            // Per-download options override this unlimited daemon default.
-            // TODO: Add per-torrent ratio overrides if one global preference becomes too limiting.
-            "--seed-ratio=0.0",
-            "--bt-save-metadata=true",
-            "--bt-load-saved-metadata=true",
-            "--follow-torrent=true",
-            "--pause=true",
-            "--allow-overwrite=false",
-            "--auto-file-renaming=true"
-        ]
-        arguments.append(contentsOf: [
-            "--summary-interval=0",
-            "--max-concurrent-downloads=\(transferSettings.maxConcurrentDownloads)",
-            "--max-overall-download-limit=\(Self.aria2LimitString(transferSettings.globalSpeedLimitBytesPerSecond))",
-            "--max-overall-upload-limit=\(Self.aria2LimitString(transferSettings.globalUploadSpeedLimitBytesPerSecond))",
-            "--max-download-limit=\(Self.aria2LimitString(transferSettings.perDownloadSpeedLimitBytesPerSecond))",
-            "--max-upload-limit=\(Self.aria2LimitString(transferSettings.perDownloadUploadSpeedLimitBytesPerSecond))",
-            "--max-connection-per-server=\(transferSettings.perDownloadConnectionCount)",
-            "--split=\(transferSettings.perDownloadConnectionCount)",
-            "--check-certificate=true",
-            "--console-log-level=notice"
-        ])
+        let arguments = Self.daemonArguments(
+            sessionFilePath: sessionFileURL.path,
+            rpcPort: port,
+            rpcSecret: secret,
+            hostProcessIdentifier: ProcessInfo.processInfo.processIdentifier,
+            transferSettings: transferSettings,
+            networkBinding: networkBinding
+        )
 
         let process = Process()
         process.executableURL = binaryURL
@@ -1045,6 +1051,57 @@ actor Aria2TorrentService {
             return
         }
         throw TorrentEngineError.startupFailed("Timed out waiting for aria2 RPC.")
+    }
+
+    nonisolated static func daemonArguments(
+        sessionFilePath: String,
+        rpcPort: Int,
+        rpcSecret: String,
+        hostProcessIdentifier: pid_t,
+        transferSettings: DownloadTransferSettings,
+        networkBinding: NetworkBindingStatus
+    ) -> [String] {
+        var arguments = [
+            "--enable-rpc=true",
+            "--rpc-listen-all=false",
+            "--rpc-listen-port=\(rpcPort)",
+            "--rpc-secret=\(rpcSecret)",
+            "--input-file=\(sessionFilePath)",
+            "--save-session=\(sessionFilePath)",
+            "--save-session-interval=5",
+            "--force-save=true",
+            "--stop-with-process=\(hostProcessIdentifier)",
+            "--bt-detach-seed-only=true",
+            // Per-download options override this unlimited daemon default.
+            // TODO: Add per-torrent ratio overrides if one global preference becomes too limiting.
+            "--seed-ratio=0.0",
+            "--bt-save-metadata=true",
+            "--bt-load-saved-metadata=true",
+            "--follow-torrent=true",
+            "--pause=true",
+            "--allow-overwrite=false",
+            "--auto-file-renaming=true"
+        ]
+        arguments.append(contentsOf: [
+            "--summary-interval=0",
+            "--max-concurrent-downloads=\(transferSettings.maxConcurrentDownloads)",
+            "--max-overall-download-limit=\(aria2LimitString(transferSettings.globalSpeedLimitBytesPerSecond))",
+            "--max-overall-upload-limit=\(aria2LimitString(transferSettings.globalUploadSpeedLimitBytesPerSecond))",
+            "--max-download-limit=\(aria2LimitString(transferSettings.perDownloadSpeedLimitBytesPerSecond))",
+            "--max-upload-limit=\(aria2LimitString(transferSettings.perDownloadUploadSpeedLimitBytesPerSecond))",
+            "--max-connection-per-server=\(transferSettings.perDownloadConnectionCount)",
+            "--split=\(transferSettings.perDownloadConnectionCount)",
+            "--check-certificate=true",
+            "--console-log-level=notice"
+        ])
+
+        // Local Peer Discovery stays off by default in aria2, so --interface is
+        // the only socket binding the daemon needs.
+        if case let .bound(_, binding) = networkBinding {
+            arguments.append("--interface=\(binding.interfaceName)")
+        }
+
+        return arguments
     }
 
     private func recoverCorruptSessionIfPossible(

--- a/Harbor/Services/NetworkBindingService.swift
+++ b/Harbor/Services/NetworkBindingService.swift
@@ -74,13 +74,13 @@ nonisolated struct SystemNetworkBindingCatalog: NetworkBindingCataloging {
 
         // SystemConfiguration exports no constant for the type a
         // NetworkExtension VPN or a Thunderbolt bridge reports, so those two
-        // are matched by the value macOS returns.
+        // are matched by the value macOS returns. PPTP is left out: macOS
+        // dropped it in 10.12, long before this app's deployment target.
         let tunnelTypes: Set<String> = [
             "VPN",
             kSCNetworkInterfaceTypeIPSec as String,
             kSCNetworkInterfaceTypePPP as String,
-            kSCNetworkInterfaceTypeL2TP as String,
-            kSCNetworkInterfaceTypePPTP as String
+            kSCNetworkInterfaceTypeL2TP as String
         ]
         let wiredTypes: Set<String> = [
             "Bridge",

--- a/Harbor/Services/NetworkBindingService.swift
+++ b/Harbor/Services/NetworkBindingService.swift
@@ -68,9 +68,15 @@ nonisolated struct SystemNetworkBindingCatalog: NetworkBindingCataloging {
         }
     }
 
-    /// A VPN service has no BSD interface until it connects. The dynamic store
-    /// publishes the interface it landed on for the duration of the connection.
+    /// A service has no BSD interface until it is up, and a VPN lands on a
+    /// different `utunN` on every connection.
     private func resolveService(id: String) -> ResolvedNetworkBinding? {
+        dynamicStoreBinding(serviceID: id) ?? vpnConnectionBinding(serviceID: id)
+    }
+
+    /// Wired and wireless services publish their live address under their own
+    /// configured identifier.
+    private func dynamicStoreBinding(serviceID: String) -> ResolvedNetworkBinding? {
         guard let store = SCDynamicStoreCreate(
             nil,
             "Harbor.NetworkBindingCatalog" as CFString,
@@ -79,10 +85,36 @@ nonisolated struct SystemNetworkBindingCatalog: NetworkBindingCataloging {
         ),
         let entry = SCDynamicStoreCopyValue(
             store,
-            "State:/Network/Service/\(id)/IPv4" as CFString
-        ) as? [String: Any],
-        let interfaceName = entry["InterfaceName"] as? String,
-        interfaceName.isEmpty == false else {
+            "State:/Network/Service/\(serviceID)/IPv4" as CFString
+        ) as? [String: Any] else {
+            return nil
+        }
+
+        return Self.binding(fromIPv4Entry: entry)
+    }
+
+    /// A VPN publishes its address under a per-session identifier that has no
+    /// link back to the configured service, so the dynamic store cannot answer
+    /// for it. SCNetworkConnection reports the same information for the stable
+    /// service identifier the selection stores.
+    private func vpnConnectionBinding(serviceID: String) -> ResolvedNetworkBinding? {
+        guard let connection = SCNetworkConnectionCreateWithServiceID(
+            nil,
+            serviceID as CFString,
+            nil,
+            nil
+        ),
+        let status = SCNetworkConnectionCopyExtendedStatus(connection) as? [String: Any],
+        let ipv4Entry = status["IPv4"] as? [String: Any] else {
+            return nil
+        }
+
+        return Self.binding(fromIPv4Entry: ipv4Entry)
+    }
+
+    static func binding(fromIPv4Entry entry: [String: Any]) -> ResolvedNetworkBinding? {
+        guard let interfaceName = entry["InterfaceName"] as? String,
+              interfaceName.isEmpty == false else {
             return nil
         }
 

--- a/Harbor/Services/NetworkBindingService.swift
+++ b/Harbor/Services/NetworkBindingService.swift
@@ -1,0 +1,324 @@
+import Darwin
+import Dispatch
+import Foundation
+import SystemConfiguration
+
+nonisolated protocol NetworkBindingCataloging: Sendable {
+    /// Everything the user can pick, starting with `.any`.
+    func availableTargets() -> [NetworkBindingTarget]
+
+    /// The interface a selection points at right now, or `nil` when the
+    /// selection carries no restriction (`.any`) or has no usable IPv4
+    /// interface at the moment.
+    func resolve(_ selection: NetworkBindingSelection) -> ResolvedNetworkBinding?
+}
+
+nonisolated struct SystemNetworkBindingCatalog: NetworkBindingCataloging {
+    func availableTargets() -> [NetworkBindingTarget] {
+        [.any] + serviceTargets() + interfaceTargets()
+    }
+
+    func resolve(_ selection: NetworkBindingSelection) -> ResolvedNetworkBinding? {
+        switch selection {
+        case .any:
+            nil
+        case let .service(id):
+            resolveService(id: id)
+        case let .interface(name):
+            Self.activeIPv4Address(forInterface: name).map {
+                ResolvedNetworkBinding(interfaceName: name, ipv4Address: $0)
+            }
+        }
+    }
+
+    private func serviceTargets() -> [NetworkBindingTarget] {
+        guard let preferences = SCPreferencesCreate(
+            nil,
+            "Harbor.NetworkBindingCatalog" as CFString,
+            nil
+        ),
+        let currentSet = SCNetworkSetCopyCurrent(preferences),
+        let services = SCNetworkSetCopyServices(currentSet) as? [SCNetworkService] else {
+            return []
+        }
+
+        return services.compactMap { service -> NetworkBindingTarget? in
+            guard SCNetworkServiceGetEnabled(service),
+                  let id = SCNetworkServiceGetServiceID(service) as String?,
+                  let name = SCNetworkServiceGetName(service) as String?,
+                  name.isEmpty == false else {
+                return nil
+            }
+
+            return NetworkBindingTarget(
+                selection: .service(id: id),
+                displayName: name,
+                kind: .service
+            )
+        }
+    }
+
+    private func interfaceTargets() -> [NetworkBindingTarget] {
+        Self.interfaceNames().map { name in
+            NetworkBindingTarget(
+                selection: .interface(name: name),
+                displayName: name,
+                kind: .interface
+            )
+        }
+    }
+
+    /// A VPN service has no BSD interface until it connects. The dynamic store
+    /// publishes the interface it landed on for the duration of the connection.
+    private func resolveService(id: String) -> ResolvedNetworkBinding? {
+        guard let store = SCDynamicStoreCreate(
+            nil,
+            "Harbor.NetworkBindingCatalog" as CFString,
+            nil,
+            nil
+        ),
+        let entry = SCDynamicStoreCopyValue(
+            store,
+            "State:/Network/Service/\(id)/IPv4" as CFString
+        ) as? [String: Any],
+        let interfaceName = entry["InterfaceName"] as? String,
+        interfaceName.isEmpty == false else {
+            return nil
+        }
+
+        return ResolvedNetworkBinding(
+            interfaceName: interfaceName,
+            ipv4Address: (entry["Addresses"] as? [String])?.first
+        )
+    }
+
+    /// Apple's own link-layer devices. `getifaddrs` reports them alongside real
+    /// adapters, but none of them can carry a user's traffic, and their flags
+    /// are indistinguishable from a real adapter's.
+    private static let hiddenInterfaceBaseNames: Set<String> = [
+        "anpi", // Apple network processor
+        "ap", // Wi-Fi access point
+        "awdl", // Apple Wireless Direct Link
+        "gif", // generic tunnel pseudo-device
+        "llw", // low-latency companion link
+        "lo", // loopback
+        "nan", // Neighbor Awareness Networking
+        "stf" // 6to4 pseudo-device
+    ]
+
+    static func isOfferableInterfaceName(_ name: String) -> Bool {
+        let baseName = name.prefix { $0.isNumber == false }
+        return hiddenInterfaceBaseNames.contains(String(baseName)) == false
+    }
+
+    static func interfaceNames() -> [String] {
+        var addressList: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&addressList) == 0, let first = addressList else {
+            return []
+        }
+        defer { freeifaddrs(addressList) }
+
+        var names: Set<String> = []
+        for address in sequence(first: first, next: { $0.pointee.ifa_next }) {
+            let name = String(cString: address.pointee.ifa_name)
+            guard isOfferableInterfaceName(name) else {
+                continue
+            }
+            names.insert(name)
+        }
+
+        return names.sorted()
+    }
+
+    static func activeIPv4Address(forInterface interfaceName: String) -> String? {
+        var addressList: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&addressList) == 0, let first = addressList else {
+            return nil
+        }
+        defer { freeifaddrs(addressList) }
+
+        for address in sequence(first: first, next: { $0.pointee.ifa_next }) {
+            guard String(cString: address.pointee.ifa_name) == interfaceName,
+                  let socketAddress = address.pointee.ifa_addr,
+                  socketAddress.pointee.sa_family == UInt8(AF_INET) else {
+                continue
+            }
+
+            let flags = Int32(address.pointee.ifa_flags)
+            guard flags & IFF_UP == IFF_UP, flags & IFF_RUNNING == IFF_RUNNING else {
+                continue
+            }
+
+            var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            guard getnameinfo(
+                socketAddress,
+                socklen_t(socketAddress.pointee.sa_len),
+                &host,
+                socklen_t(host.count),
+                nil,
+                0,
+                NI_NUMERICHOST
+            ) == 0 else {
+                continue
+            }
+
+            return String(cString: host)
+        }
+
+        return nil
+    }
+}
+
+private let networkBindingStoreCallback: SCDynamicStoreCallBack = { _, _, info in
+    guard let info else {
+        return
+    }
+
+    // The store delivers on the queue set below, which is the main queue.
+    MainActor.assumeIsolated {
+        Unmanaged<NetworkBindingMonitor>
+            .fromOpaque(info)
+            .takeUnretainedValue()
+            .scheduleRefresh()
+    }
+}
+
+/// Watches the selected network path and reports whether torrent traffic can be
+/// bound to it right now.
+@MainActor
+final class NetworkBindingMonitor {
+    private let catalog: any NetworkBindingCataloging
+    private let debounceInterval: TimeInterval
+
+    private var selection: NetworkBindingSelection = .any
+    private var displayName = ""
+    private var dynamicStore: SCDynamicStore?
+    private var debounceWorkItem: DispatchWorkItem?
+
+    private(set) var status: NetworkBindingStatus = .unrestricted {
+        didSet {
+            guard status != oldValue else {
+                return
+            }
+            statusDidChange?(status)
+        }
+    }
+
+    var statusDidChange: ((NetworkBindingStatus) -> Void)? {
+        didSet {
+            statusDidChange?(status)
+        }
+    }
+
+    init(
+        catalog: (any NetworkBindingCataloging)? = nil,
+        debounceInterval: TimeInterval = 0.4
+    ) {
+        self.catalog = catalog ?? SystemNetworkBindingCatalog()
+        self.debounceInterval = debounceInterval
+    }
+
+    deinit {
+        debounceWorkItem?.cancel()
+        if let dynamicStore {
+            SCDynamicStoreSetDispatchQueue(dynamicStore, nil)
+        }
+    }
+
+    func start(selection: NetworkBindingSelection, displayName: String) {
+        stopObserving()
+        self.selection = selection
+        self.displayName = displayName
+
+        // The owner acts on this status even when it did not change, because a
+        // different selection can resolve to the same interface.
+        publish(resolvedStatus(), alwaysNotify: true)
+
+        guard selection != .any else {
+            return
+        }
+        beginObserving()
+    }
+
+    func stop() {
+        stopObserving()
+        selection = .any
+        displayName = ""
+        publish(.unrestricted, alwaysNotify: false)
+    }
+
+    fileprivate func scheduleRefresh() {
+        debounceWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.refreshStatus()
+            }
+        }
+        debounceWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + debounceInterval, execute: workItem)
+    }
+
+    /// Re-resolves the current selection and reports the result.
+    func refreshStatus() {
+        publish(resolvedStatus(), alwaysNotify: false)
+    }
+
+    private func resolvedStatus() -> NetworkBindingStatus {
+        guard selection != .any else {
+            return .unrestricted
+        }
+
+        guard let binding = catalog.resolve(selection) else {
+            return .unavailable(displayName: displayName)
+        }
+
+        return .bound(displayName: displayName, binding: binding)
+    }
+
+    private func publish(_ newStatus: NetworkBindingStatus, alwaysNotify: Bool) {
+        let didChange = status != newStatus
+        status = newStatus
+        if alwaysNotify, didChange == false {
+            statusDidChange?(status)
+        }
+    }
+
+    private func beginObserving() {
+        var context = SCDynamicStoreContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        guard let store = SCDynamicStoreCreate(
+            nil,
+            "Harbor.NetworkBindingMonitor" as CFString,
+            networkBindingStoreCallback,
+            &context
+        ) else {
+            return
+        }
+
+        SCDynamicStoreSetNotificationKeys(
+            store,
+            ["State:/Network/Global/IPv4"] as CFArray,
+            [
+                "State:/Network/Service/[^/]+/IPv4",
+                "State:/Network/Interface/[^/]+/Link"
+            ] as CFArray
+        )
+        SCDynamicStoreSetDispatchQueue(store, .main)
+        dynamicStore = store
+    }
+
+    private func stopObserving() {
+        debounceWorkItem?.cancel()
+        debounceWorkItem = nil
+        if let dynamicStore {
+            SCDynamicStoreSetDispatchQueue(dynamicStore, nil)
+        }
+        dynamicStore = nil
+    }
+}

--- a/Harbor/Services/NetworkBindingService.swift
+++ b/Harbor/Services/NetworkBindingService.swift
@@ -42,7 +42,7 @@ nonisolated struct SystemNetworkBindingCatalog: NetworkBindingCataloging {
             return []
         }
 
-        return services.compactMap { service -> NetworkBindingTarget? in
+        let targets = services.compactMap { service -> NetworkBindingTarget? in
             guard SCNetworkServiceGetEnabled(service),
                   let id = SCNetworkServiceGetServiceID(service) as String?,
                   let name = SCNetworkServiceGetName(service) as String?,
@@ -57,17 +57,19 @@ nonisolated struct SystemNetworkBindingCatalog: NetworkBindingCataloging {
                 selection: .service(id: id),
                 displayName: name,
                 kind: .service,
-                symbolName: Self.symbolName(forInterfaceType: interfaceType)
+                medium: Self.medium(forInterfaceType: interfaceType)
             )
         }
+
+        return NetworkBindingTarget.sortedByMedium(targets)
     }
 
     /// macOS reports what a service runs over, which is the only reliable way
     /// to tell a VPN from an ordinary connection: a VPN has no BSD name until
     /// it connects, and its flags match a real adapter's once it does.
-    static func symbolName(forInterfaceType interfaceType: String?) -> String {
+    static func medium(forInterfaceType interfaceType: String?) -> NetworkBindingMedium {
         guard let interfaceType else {
-            return "network"
+            return .other
         }
 
         // SystemConfiguration exports no constant for the type a
@@ -88,26 +90,57 @@ nonisolated struct SystemNetworkBindingCatalog: NetworkBindingCataloging {
         ]
 
         if tunnelTypes.contains(interfaceType) {
-            return "lock.shield"
+            return .vpn
         }
         if interfaceType == kSCNetworkInterfaceTypeIEEE80211 as String {
-            return "wifi"
+            return .wireless
         }
         if wiredTypes.contains(interfaceType) {
-            return "cable.connector"
+            return .wired
         }
-        return "network"
+        return .other
     }
 
     private func interfaceTargets() -> [NetworkBindingTarget] {
-        Self.interfaceNames().map { name in
+        let mediums = Self.interfaceMediums()
+
+        let targets = Self.interfaceNames().map { name in
             NetworkBindingTarget(
                 selection: .interface(name: name),
                 displayName: name,
                 kind: .interface,
-                symbolName: name.hasPrefix("utun") ? "lock.shield" : "network"
+                medium: mediums[name] ?? Self.medium(forInterfaceName: name)
             )
         }
+
+        return NetworkBindingTarget.sortedByMedium(targets)
+    }
+
+    /// What every adapter macOS knows about runs over, keyed by BSD name. This
+    /// is what tells `en0` (Wi-Fi) from `en5` (a USB Ethernet adapter), which
+    /// the name alone never reveals.
+    private static func interfaceMediums() -> [String: NetworkBindingMedium] {
+        guard let interfaces = SCNetworkInterfaceCopyAll() as? [SCNetworkInterface] else {
+            return [:]
+        }
+
+        return interfaces.reduce(into: [:]) { mediums, interface in
+            guard let bsdName = SCNetworkInterfaceGetBSDName(interface) as String? else {
+                return
+            }
+
+            mediums[bsdName] = medium(
+                forInterfaceType: SCNetworkInterfaceGetInterfaceType(interface) as String?
+            )
+        }
+    }
+
+    /// A tunnel has no SCNetworkInterface — it exists only while it is up — so
+    /// its name is all there is to classify it by.
+    static func medium(forInterfaceName name: String) -> NetworkBindingMedium {
+        let tunnelBaseNames: Set<String> = ["utun", "ipsec", "ppp", "tun", "tap"]
+        let baseName = String(name.prefix { $0.isNumber == false })
+        return tunnelBaseNames.contains(baseName) ? .vpn : .other
     }
 
     /// A service has no BSD interface until it is up, and a VPN lands on a

--- a/Harbor/Services/NetworkBindingService.swift
+++ b/Harbor/Services/NetworkBindingService.swift
@@ -50,12 +50,53 @@ nonisolated struct SystemNetworkBindingCatalog: NetworkBindingCataloging {
                 return nil
             }
 
+            let interfaceType = SCNetworkServiceGetInterface(service)
+                .flatMap { SCNetworkInterfaceGetInterfaceType($0) as String? }
+
             return NetworkBindingTarget(
                 selection: .service(id: id),
                 displayName: name,
-                kind: .service
+                kind: .service,
+                symbolName: Self.symbolName(forInterfaceType: interfaceType)
             )
         }
+    }
+
+    /// macOS reports what a service runs over, which is the only reliable way
+    /// to tell a VPN from an ordinary connection: a VPN has no BSD name until
+    /// it connects, and its flags match a real adapter's once it does.
+    static func symbolName(forInterfaceType interfaceType: String?) -> String {
+        guard let interfaceType else {
+            return "network"
+        }
+
+        // SystemConfiguration exports no constant for the type a
+        // NetworkExtension VPN or a Thunderbolt bridge reports, so those two
+        // are matched by the value macOS returns.
+        let tunnelTypes: Set<String> = [
+            "VPN",
+            kSCNetworkInterfaceTypeIPSec as String,
+            kSCNetworkInterfaceTypePPP as String,
+            kSCNetworkInterfaceTypeL2TP as String,
+            kSCNetworkInterfaceTypePPTP as String
+        ]
+        let wiredTypes: Set<String> = [
+            "Bridge",
+            kSCNetworkInterfaceTypeEthernet as String,
+            kSCNetworkInterfaceTypeBond as String,
+            kSCNetworkInterfaceTypeVLAN as String
+        ]
+
+        if tunnelTypes.contains(interfaceType) {
+            return "lock.shield"
+        }
+        if interfaceType == kSCNetworkInterfaceTypeIEEE80211 as String {
+            return "wifi"
+        }
+        if wiredTypes.contains(interfaceType) {
+            return "cable.connector"
+        }
+        return "network"
     }
 
     private func interfaceTargets() -> [NetworkBindingTarget] {
@@ -63,7 +104,8 @@ nonisolated struct SystemNetworkBindingCatalog: NetworkBindingCataloging {
             NetworkBindingTarget(
                 selection: .interface(name: name),
                 displayName: name,
-                kind: .interface
+                kind: .interface,
+                symbolName: name.hasPrefix("utun") ? "lock.shield" : "network"
             )
         }
     }

--- a/Harbor/ViewModels/DownloadCenter.swift
+++ b/Harbor/ViewModels/DownloadCenter.swift
@@ -98,6 +98,7 @@ final class DownloadCenter {
     @ObservationIgnored private let managedTorrentSourceStore: ManagedTorrentSourceStore
     @ObservationIgnored private let torrentSidecarFileService: TorrentSidecarFileService
     @ObservationIgnored private let torrentWatchFolderService: TorrentWatchFolderService
+    @ObservationIgnored private let networkBindingMonitor: NetworkBindingMonitor
     @ObservationIgnored private let directPauseOperation: DirectPauseOperation
     @ObservationIgnored private let mediaCleanupOperation: MediaCleanupOperation
     @ObservationIgnored private let mediaPauseOperation: MediaPauseOperation
@@ -128,6 +129,10 @@ final class DownloadCenter {
     @ObservationIgnored private var pendingMediaRecoveryResets: Set<UUID> = []
     @ObservationIgnored private var torrentStartTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored private var torrentPauseTasks: [UUID: Task<Void, Never>] = [:]
+    @ObservationIgnored private var networkBindingTask: Task<Void, Never>?
+    /// Downloads Harbor paused because the bound interface disappeared. Kept in
+    /// memory so a manual pause is never mistaken for one of these.
+    @ObservationIgnored private var networkSuspendedDownloadIDs: Set<UUID> = []
     @ObservationIgnored private var torrentStopSeedingTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored private var pendingTorrentPauseIDs: Set<UUID> = []
     @ObservationIgnored private var pendingTorrentSeedingRestartIDs: Set<UUID> = []
@@ -204,6 +209,7 @@ final class DownloadCenter {
         managedTorrentSourceStore: ManagedTorrentSourceStore = ManagedTorrentSourceStore(),
         torrentSidecarFileService: TorrentSidecarFileService = TorrentSidecarFileService(),
         torrentWatchFolderService: TorrentWatchFolderService? = nil,
+        networkBindingMonitor: NetworkBindingMonitor? = nil,
         sleepPreventionService: (any DownloadSleepPreventing)? = nil,
         quickLookPreviewService: (any QuickLookPreviewing)? = nil,
         torrentService: Aria2TorrentService? = nil,
@@ -260,6 +266,7 @@ final class DownloadCenter {
         self.managedTorrentSourceStore = managedTorrentSourceStore
         self.torrentSidecarFileService = torrentSidecarFileService
         self.torrentWatchFolderService = torrentWatchFolderService ?? TorrentWatchFolderService()
+        self.networkBindingMonitor = networkBindingMonitor ?? NetworkBindingMonitor()
         self.sleepPreventionService = sleepPreventionService ?? DownloadSleepPreventionService()
         self.quickLookPreviewService = quickLookPreviewService ?? QuickLookPreviewService()
         self.torrentService = torrentService ?? Aria2TorrentService(transferSettings: settings.transferSettings)
@@ -303,6 +310,12 @@ final class DownloadCenter {
         self.torrentWatchFolderService.statusDidChange = { [weak self] status in
             self?.handleTorrentWatchFolderStatus(status)
         }
+        settings.networkBindingDidChange = { [weak self] _ in
+            self?.configureNetworkBinding()
+        }
+        self.networkBindingMonitor.statusDidChange = { [weak self] status in
+            self?.handleNetworkBindingStatus(status)
+        }
         monitorSleepPrevention()
     }
 
@@ -311,8 +324,10 @@ final class DownloadCenter {
         torrentRefreshTask?.cancel()
         directRetryTasks.values.forEach { $0.cancel() }
         orphanedTorrentCleanupTasks.values.forEach { $0.cancel() }
-        Task { @MainActor [torrentWatchFolderService] in
+        networkBindingTask?.cancel()
+        Task { @MainActor [torrentWatchFolderService, networkBindingMonitor] in
             torrentWatchFolderService.stop()
+            networkBindingMonitor.stop()
         }
         Task { [mediaService] in
             await mediaService?.shutdown()
@@ -339,6 +354,11 @@ final class DownloadCenter {
         var orphanCleanupWarning: String?
 
         do {
+            // Session recovery below talks to aria2. The engine must already
+            // know its interface by then, or a restored torrent would briefly
+            // transfer over whatever route the system happens to prefer.
+            await applyNetworkBindingBeforeEngineUse()
+
             do {
                 try await mediaService.terminateOrphanedMediaProcesses()
             } catch {
@@ -1877,6 +1897,93 @@ final class DownloadCenter {
         }
     }
 
+    /// Establishes the binding and waits until the engine has it, so no
+    /// daemon can start before Harbor knows which interface it may use.
+    private func applyNetworkBindingBeforeEngineUse() async {
+        configureNetworkBinding()
+        await networkBindingTask?.value
+    }
+
+    private func configureNetworkBinding() {
+        guard isShuttingDown == false else {
+            return
+        }
+
+        networkBindingMonitor.start(
+            selection: settings.networkBindingSelection,
+            displayName: settings.networkBindingDisplayName
+        )
+    }
+
+    private func handleNetworkBindingStatus(_ status: NetworkBindingStatus) {
+        settings.updateNetworkBindingStatus(status)
+
+        guard isShuttingDown == false else {
+            return
+        }
+
+        switch status {
+        case .unavailable:
+            suspendTorrentsForUnavailableNetwork(status)
+        case .unrestricted, .bound:
+            resumeTorrentsForAvailableNetwork(status)
+        }
+    }
+
+    private func suspendTorrentsForUnavailableNetwork(_ status: NetworkBindingStatus) {
+        let suspendableItems = downloads.filter {
+            $0.backend == .aria2 && ($0.canPause || $0.status == .queued)
+        }
+
+        for item in suspendableItems {
+            networkSuspendedDownloadIDs.insert(item.id)
+            pauseDownload(id: item.id)
+        }
+
+        if suspendableItems.isEmpty == false {
+            schedulePersist()
+        }
+
+        let previousBindingTask = networkBindingTask
+        networkBindingTask = Task { @MainActor [weak self] in
+            await previousBindingTask?.value
+            guard let self else {
+                return
+            }
+
+            // Pausing travels over RPC, so the daemon has to outlive it. Only
+            // then may the engine refuse to run without the interface.
+            await waitForTasks(Array(torrentPauseTasks.values))
+            await torrentService.setNetworkBinding(status)
+        }
+    }
+
+    private func resumeTorrentsForAvailableNetwork(_ status: NetworkBindingStatus) {
+        let resumableIDs = networkSuspendedDownloadIDs
+        networkSuspendedDownloadIDs.removeAll()
+
+        let previousBindingTask = networkBindingTask
+        networkBindingTask = Task { @MainActor [weak self] in
+            await previousBindingTask?.value
+            guard let self else {
+                return
+            }
+
+            // The engine has to know the new interface before anything restarts
+            // on it.
+            await torrentService.setNetworkBinding(status)
+
+            // A suspended seeder is paused too, and resuming it restarts
+            // seeding the same way the sidebar action would.
+            for id in resumableIDs {
+                guard let item = item(for: id), item.status == .paused else {
+                    continue
+                }
+                resumeDownload(item)
+            }
+        }
+    }
+
     private func handleTorrentWatchFolderStatus(_ status: TorrentWatchFolderStatus) {
         settings.updateTorrentWatchFolderStatus(status)
 
@@ -1978,6 +2085,9 @@ final class DownloadCenter {
         directRetryTasks.removeAll()
         readyDirectRetries.removeAll()
         torrentWatchFolderService.stop()
+        networkBindingMonitor.stop()
+        networkBindingTask?.cancel()
+        networkBindingTask = nil
 
         await pendingTorrentRefresh?.value
         await cancelOrphanedTorrentCleanupTasksAndWait()
@@ -2217,6 +2327,7 @@ final class DownloadCenter {
         isShuttingDown = false
         resumeDeferredSeedersAfterFailedShutdown()
         configureTorrentWatchFolder()
+        configureNetworkBinding()
         startTorrentRefreshLoopIfNeeded()
         startNextQueuedDownloadsIfNeeded()
     }
@@ -2231,6 +2342,9 @@ final class DownloadCenter {
         directRetryTasks.removeAll()
         readyDirectRetries.removeAll()
         torrentWatchFolderService.stop()
+        networkBindingMonitor.stop()
+        networkBindingTask?.cancel()
+        networkBindingTask = nil
         await cancelPendingPersistenceAndWait()
         await pendingTorrentRefresh?.value
 
@@ -5195,7 +5309,7 @@ final class DownloadCenter {
                 return
             }
 
-            if hadBackendIdentifier, isTransientTorrentEngineError(error) {
+            if hadBackendIdentifier, Self.isTransientTorrentEngineError(error) {
                 // A failed status lookup is not proof that an existing aria2
                 // transfer is paused. Keep its slot occupied until a later
                 // refresh confirms a non-writing state.
@@ -5965,7 +6079,7 @@ final class DownloadCenter {
                     continue
                 }
 
-                if isTransientTorrentEngineError(error) {
+                if Self.isTransientTorrentEngineError(error) {
                     refreshedItem.speedBytesPerSecond = 0
                     refreshedItem.uploadBytesPerSecond = 0
                     refreshedItem.updatedAt = .now
@@ -7771,7 +7885,7 @@ final class DownloadCenter {
         )
     }
 
-    private func isTransientTorrentEngineError(_ error: Error) -> Bool {
+    nonisolated static func isTransientTorrentEngineError(_ error: Error) -> Bool {
         if let urlError = error as? URLError {
             switch urlError.code {
             case .timedOut, .cannotConnectToHost, .cannotFindHost, .networkConnectionLost, .notConnectedToInternet:
@@ -7783,6 +7897,13 @@ final class DownloadCenter {
 
         if case let TorrentEngineError.startupFailed(message) = error {
             return message.localizedCaseInsensitiveContains("timed out")
+        }
+
+        // A missing bound interface means Harbor deliberately stopped the
+        // engine. The transfers are suspended, not broken, so they keep their
+        // status and can resume once the interface returns.
+        if case TorrentEngineError.networkInterfaceUnavailable = error {
+            return true
         }
 
         return false

--- a/Harbor/Views/HarborAccessibility.swift
+++ b/Harbor/Views/HarborAccessibility.swift
@@ -50,6 +50,7 @@ enum HarborAccessibility {
     static let settingsGeneral = "settings.general"
     static let settingsDownloads = "settings.downloads"
     static let settingsTorrents = "settings.torrents"
+    static let settingsNetworkInterfacePicker = "settings.torrents.networkInterface"
     static let settingsBandwidth = "settings.bandwidth"
     static let settingsUpdates = "settings.updates"
     static let settingsAcknowledgments = "settings.acknowledgments"

--- a/Harbor/Views/SettingsTabs.swift
+++ b/Harbor/Views/SettingsTabs.swift
@@ -74,18 +74,20 @@ struct TorrentsSettingsTab: View {
                     .tag(NetworkBindingSelection.any)
 
                     if serviceTargets.isEmpty == false {
-                        Divider()
-                        ForEach(serviceTargets) { target in
-                            Label(target.displayName, systemImage: target.symbolName)
-                                .tag(target.selection)
+                        Section("Services") {
+                            ForEach(serviceTargets) { target in
+                                Label(target.displayName, systemImage: target.symbolName)
+                                    .tag(target.selection)
+                            }
                         }
                     }
 
                     if interfaceTargets.isEmpty == false {
-                        Divider()
-                        ForEach(interfaceTargets) { target in
-                            Label(target.displayName, systemImage: target.symbolName)
-                                .tag(target.selection)
+                        Section("Interfaces") {
+                            ForEach(interfaceTargets) { target in
+                                Label(target.displayName, systemImage: target.symbolName)
+                                    .tag(target.selection)
+                            }
                         }
                     }
                 }

--- a/Harbor/Views/SettingsTabs.swift
+++ b/Harbor/Views/SettingsTabs.swift
@@ -67,20 +67,25 @@ struct TorrentsSettingsTab: View {
         Form {
             Section("Network") {
                 Picker("Network Interface", selection: $settings.networkBindingSelection) {
-                    Text(NetworkBindingTarget.any.displayName)
-                        .tag(NetworkBindingSelection.any)
+                    Label(
+                        NetworkBindingTarget.any.displayName,
+                        systemImage: NetworkBindingTarget.any.symbolName
+                    )
+                    .tag(NetworkBindingSelection.any)
 
                     if serviceTargets.isEmpty == false {
                         Divider()
                         ForEach(serviceTargets) { target in
-                            Text(target.displayName).tag(target.selection)
+                            Label(target.displayName, systemImage: target.symbolName)
+                                .tag(target.selection)
                         }
                     }
 
                     if interfaceTargets.isEmpty == false {
                         Divider()
                         ForEach(interfaceTargets) { target in
-                            Text(target.displayName).tag(target.selection)
+                            Label(target.displayName, systemImage: target.symbolName)
+                                .tag(target.selection)
                         }
                     }
                 }

--- a/Harbor/Views/SettingsTabs.swift
+++ b/Harbor/Views/SettingsTabs.swift
@@ -65,6 +65,36 @@ struct TorrentsSettingsTab: View {
         @Bindable var settings = settings
 
         Form {
+            Section("Network") {
+                Picker("Network Interface", selection: $settings.networkBindingSelection) {
+                    Text(NetworkBindingTarget.any.displayName)
+                        .tag(NetworkBindingSelection.any)
+
+                    if serviceTargets.isEmpty == false {
+                        Divider()
+                        ForEach(serviceTargets) { target in
+                            Text(target.displayName).tag(target.selection)
+                        }
+                    }
+
+                    if interfaceTargets.isEmpty == false {
+                        Divider()
+                        ForEach(interfaceTargets) { target in
+                            Text(target.displayName).tag(target.selection)
+                        }
+                    }
+                }
+                .accessibilityIdentifier(HarborAccessibility.settingsNetworkInterfacePicker)
+
+                if settings.networkBindingSelection != .any {
+                    NetworkBindingStatusRow(status: settings.networkBindingStatus)
+                }
+
+                Text("Torrent traffic uses only the selected interface. While that interface is unavailable, Harbor pauses every torrent and resumes it once the interface returns. Regular and media downloads are not affected.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Automation") {
                 Toggle("Watch a folder for torrent files", isOn: $settings.torrentWatchFolderEnabled)
 
@@ -110,12 +140,23 @@ struct TorrentsSettingsTab: View {
             }
         }
         .formStyle(.grouped)
+        .onAppear {
+            settings.refreshNetworkBindingTargets()
+        }
         .onChange(of: settings.stopSeedingRatio) { _, value in
             let clampedValue = AppSettingsStore.clampedSeedingRatio(value)
             if clampedValue != value {
                 settings.stopSeedingRatio = clampedValue
             }
         }
+    }
+
+    private var serviceTargets: [NetworkBindingTarget] {
+        settings.networkBindingPickerTargets.filter { $0.kind == .service }
+    }
+
+    private var interfaceTargets: [NetworkBindingTarget] {
+        settings.networkBindingPickerTargets.filter { $0.kind == .interface }
     }
 }
 
@@ -289,6 +330,61 @@ private struct TorrentWatchStatusRow: View {
         case .stopped:
             .secondary
         case .watching:
+            .green
+        case .unavailable:
+            .orange
+        }
+    }
+}
+
+private struct NetworkBindingStatusRow: View {
+    let status: NetworkBindingStatus
+
+    var body: some View {
+        LabeledContent("Status") {
+            Label(message, systemImage: symbolName)
+                .foregroundStyle(foregroundStyle)
+        }
+    }
+
+    private var message: String {
+        switch status {
+        case .unrestricted:
+            String(localized: "No interface restriction")
+        case let .bound(_, binding):
+            if let ipv4Address = binding.ipv4Address {
+                String(
+                    format: String(localized: "Bound to %1$@ (%2$@)"),
+                    binding.interfaceName,
+                    ipv4Address
+                )
+            } else {
+                String(format: String(localized: "Bound to %@"), binding.interfaceName)
+            }
+        case let .unavailable(displayName):
+            String(
+                format: String(localized: "%@ is unavailable; torrents are paused"),
+                displayName
+            )
+        }
+    }
+
+    private var symbolName: String {
+        switch status {
+        case .unrestricted:
+            "circle"
+        case .bound:
+            "checkmark.shield"
+        case .unavailable:
+            "exclamationmark.triangle"
+        }
+    }
+
+    private var foregroundStyle: Color {
+        switch status {
+        case .unrestricted:
+            .secondary
+        case .bound:
             .green
         case .unavailable:
             .orange

--- a/HarborTests/NetworkBindingTests.swift
+++ b/HarborTests/NetworkBindingTests.swift
@@ -147,6 +147,28 @@ final class NetworkBindingTests: XCTestCase {
         XCTAssertEqual(pickerTarget.displayName, "ProtonVPN (unavailable)")
     }
 
+    func testIPv4EntriesResolveToABinding() {
+        XCTAssertEqual(
+            SystemNetworkBindingCatalog.binding(
+                fromIPv4Entry: ["InterfaceName": "utun4", "Addresses": ["10.2.0.2"]]
+            ),
+            ResolvedNetworkBinding(interfaceName: "utun4", ipv4Address: "10.2.0.2")
+        )
+
+        // A service that is configured but not up carries no interface.
+        XCTAssertNil(SystemNetworkBindingCatalog.binding(fromIPv4Entry: [:]))
+        XCTAssertNil(
+            SystemNetworkBindingCatalog.binding(fromIPv4Entry: ["InterfaceName": ""])
+        )
+
+        // An interface without an address still binds; aria2 resolves the
+        // family itself.
+        XCTAssertEqual(
+            SystemNetworkBindingCatalog.binding(fromIPv4Entry: ["InterfaceName": "en0"]),
+            ResolvedNetworkBinding(interfaceName: "en0", ipv4Address: nil)
+        )
+    }
+
     func testOnlyUsableInterfacesAreOffered() {
         for name in ["en0", "en5", "utun4", "bridge0", "ppp0"] {
             XCTAssertTrue(

--- a/HarborTests/NetworkBindingTests.swift
+++ b/HarborTests/NetworkBindingTests.swift
@@ -1,0 +1,384 @@
+import Foundation
+import XCTest
+@testable import Harbor
+
+private final class FakeNetworkBindingCatalog: NetworkBindingCataloging, @unchecked Sendable {
+    nonisolated(unsafe) var resolvedBinding: ResolvedNetworkBinding?
+
+    private let targets: [NetworkBindingTarget]
+    private let eventLog: EventLog?
+
+    init(
+        targets: [NetworkBindingTarget],
+        resolvedBinding: ResolvedNetworkBinding? = nil,
+        eventLog: EventLog? = nil
+    ) {
+        self.targets = targets
+        self.resolvedBinding = resolvedBinding
+        self.eventLog = eventLog
+    }
+
+    func availableTargets() -> [NetworkBindingTarget] {
+        [.any] + targets
+    }
+
+    func resolve(_ selection: NetworkBindingSelection) -> ResolvedNetworkBinding? {
+        guard selection != .any else {
+            return nil
+        }
+        eventLog?.record("resolvedBinding")
+        return resolvedBinding
+    }
+}
+
+private final class EventLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [String] = []
+
+    func record(_ event: String) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    var recorded: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
+private let vpnSelection = NetworkBindingSelection.service(id: "vpn-service-id")
+
+private func makeVPNCatalog(
+    resolvedBinding: ResolvedNetworkBinding? = nil,
+    eventLog: EventLog? = nil
+) -> FakeNetworkBindingCatalog {
+    FakeNetworkBindingCatalog(
+        targets: [
+            NetworkBindingTarget(
+                selection: vpnSelection,
+                displayName: "ProtonVPN",
+                kind: .service
+            ),
+            NetworkBindingTarget(
+                selection: .interface(name: "en0"),
+                displayName: "en0",
+                kind: .interface
+            )
+        ],
+        resolvedBinding: resolvedBinding,
+        eventLog: eventLog
+    )
+}
+
+@MainActor
+final class NetworkBindingTests: XCTestCase {
+    func testSelectionRoundTripsThroughStorageValue() {
+        for selection in [
+            NetworkBindingSelection.any,
+            .service(id: "2EB5D77A-7174-4D95-A2C7-7512BEE9BD57"),
+            .interface(name: "utun6")
+        ] {
+            XCTAssertEqual(
+                NetworkBindingSelection(storageValue: selection.storageValue),
+                selection
+            )
+        }
+    }
+
+    func testUnreadableStoredSelectionFallsBackToAny() {
+        XCTAssertEqual(NetworkBindingSelection(storageValue: ""), .any)
+        XCTAssertEqual(NetworkBindingSelection(storageValue: "nonsense"), .any)
+        XCTAssertEqual(NetworkBindingSelection(storageValue: "service:"), .any)
+        XCTAssertEqual(NetworkBindingSelection(storageValue: "interface:"), .any)
+    }
+
+    func testNetworkBindingSelectionDefaultsToAnyAndPersists() throws {
+        let suiteName = "HarborTests.NetworkBindingSelection.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        userDefaults.removePersistentDomain(forName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = AppSettingsStore(
+            userDefaults: userDefaults,
+            networkBindingCatalog: makeVPNCatalog()
+        )
+        XCTAssertEqual(settings.networkBindingSelection, .any)
+
+        var observedSelection: NetworkBindingSelection?
+        settings.networkBindingDidChange = { observedSelection = $0 }
+        settings.networkBindingSelection = vpnSelection
+
+        XCTAssertEqual(observedSelection, vpnSelection)
+        XCTAssertEqual(settings.networkBindingDisplayName, "ProtonVPN")
+
+        let restoredSettings = AppSettingsStore(
+            userDefaults: userDefaults,
+            networkBindingCatalog: makeVPNCatalog()
+        )
+        XCTAssertEqual(restoredSettings.networkBindingSelection, vpnSelection)
+        XCTAssertEqual(restoredSettings.networkBindingDisplayName, "ProtonVPN")
+    }
+
+    func testPickerKeepsAStoredSelectionThatNoLongerExists() throws {
+        let suiteName = "HarborTests.NetworkBindingMissing.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        userDefaults.removePersistentDomain(forName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = AppSettingsStore(
+            userDefaults: userDefaults,
+            networkBindingCatalog: makeVPNCatalog()
+        )
+        settings.networkBindingSelection = vpnSelection
+
+        // The VPN configuration is gone on the next launch.
+        let restoredSettings = AppSettingsStore(
+            userDefaults: userDefaults,
+            networkBindingCatalog: FakeNetworkBindingCatalog(targets: [])
+        )
+
+        XCTAssertEqual(restoredSettings.networkBindingSelection, vpnSelection)
+        let pickerTarget = try XCTUnwrap(
+            restoredSettings.networkBindingPickerTargets
+                .first { $0.selection == vpnSelection }
+        )
+        XCTAssertEqual(pickerTarget.displayName, "ProtonVPN (unavailable)")
+    }
+
+    func testOnlyUsableInterfacesAreOffered() {
+        for name in ["en0", "en5", "utun4", "bridge0", "ppp0"] {
+            XCTAssertTrue(
+                SystemNetworkBindingCatalog.isOfferableInterfaceName(name),
+                "\(name) should be offered"
+            )
+        }
+
+        for name in ["lo0", "anpi0", "anpi1", "ap1", "awdl0", "llw0", "nan0", "gif0", "stf0"] {
+            XCTAssertFalse(
+                SystemNetworkBindingCatalog.isOfferableInterfaceName(name),
+                "\(name) is an Apple-internal device and must stay out of the picker"
+            )
+        }
+    }
+
+    func testDaemonArgumentsBindTheInterfaceOnlyWhileBound() {
+        func arguments(for networkBinding: NetworkBindingStatus) -> [String] {
+            Aria2TorrentService.daemonArguments(
+                sessionFilePath: "/tmp/aria2.session",
+                rpcPort: 18_000,
+                rpcSecret: "secret",
+                hostProcessIdentifier: 42,
+                transferSettings: .default,
+                networkBinding: networkBinding
+            )
+        }
+
+        let bound = arguments(
+            for: .bound(
+                displayName: "ProtonVPN",
+                binding: ResolvedNetworkBinding(
+                    interfaceName: "utun6",
+                    ipv4Address: "10.2.0.2"
+                )
+            )
+        )
+        XCTAssertEqual(
+            bound.filter { $0.hasPrefix("--interface=") },
+            ["--interface=utun6"]
+        )
+        XCTAssertTrue(bound.contains("--rpc-listen-all=false"))
+
+        for networkBinding in [
+            NetworkBindingStatus.unrestricted,
+            .unavailable(displayName: "ProtonVPN")
+        ] {
+            XCTAssertFalse(
+                arguments(for: networkBinding).contains { $0.hasPrefix("--interface=") }
+            )
+        }
+    }
+
+    func testAnUnavailableInterfaceIsTreatedAsTransientRatherThanFailure() {
+        XCTAssertTrue(
+            DownloadCenter.isTransientTorrentEngineError(
+                TorrentEngineError.networkInterfaceUnavailable("ProtonVPN")
+            ),
+            "A suspended transfer must keep its status instead of failing"
+        )
+        XCTAssertFalse(
+            DownloadCenter.isTransientTorrentEngineError(
+                TorrentEngineError.rpc("Unauthorized")
+            )
+        )
+    }
+
+    func testEngineRefusesToStartWhileTheBoundInterfaceIsUnavailable() async {
+        let service = Aria2TorrentService()
+        await service.setNetworkBinding(.unavailable(displayName: "ProtonVPN"))
+
+        do {
+            _ = try await service.allKnownGIDs()
+            XCTFail("The engine started without its bound interface")
+        } catch {
+            XCTAssertTrue(
+                error.localizedDescription.contains("ProtonVPN"),
+                "Unexpected message: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func testStartupBindsTheEngineBeforeItRecoversTorrents() async throws {
+        let suiteName = "HarborTests.NetworkBindingStartup.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        userDefaults.removePersistentDomain(forName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let fileManager = FileManager.default
+        let persistenceRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("HarborNetworkStartupTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: persistenceRoot) }
+
+        // The VPN is down while Harbor launches.
+        let eventLog = EventLog()
+        let catalog = makeVPNCatalog(resolvedBinding: nil, eventLog: eventLog)
+        let settings = AppSettingsStore(
+            userDefaults: userDefaults,
+            networkBindingCatalog: catalog
+        )
+        // Set before the center exists, so no callback resolves the selection
+        // ahead of the ordering this test measures.
+        settings.networkBindingSelection = vpnSelection
+
+        let center = DownloadCenter(
+            settings: settings,
+            persistence: DownloadPersistence(directoryURL: persistenceRoot),
+            networkBindingMonitor: NetworkBindingMonitor(catalog: catalog, debounceInterval: 0),
+            torrentService: Aria2TorrentService(
+                daemonStartupOperation: { _ in eventLog.record("startedEngine") }
+            )
+        )
+        await center.initializeIfNeeded()
+
+        // Session recovery inside initializeIfNeeded reaches for the engine.
+        // The binding has to be resolved and applied before it does.
+        XCTAssertEqual(eventLog.recorded.first, "resolvedBinding")
+        XCTAssertTrue(
+            eventLog.recorded.contains("startedEngine"),
+            "Expected startup to reach the torrent engine at all"
+        )
+        XCTAssertEqual(
+            settings.networkBindingStatus,
+            .unavailable(displayName: "ProtonVPN")
+        )
+
+        await center.shutdownForTermination()
+    }
+
+    func testLosingTheBoundInterfacePausesTorrentsAndRegainingItResumesThem() async throws {
+        let suiteName = "HarborTests.NetworkKillSwitch.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        userDefaults.removePersistentDomain(forName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let fileManager = FileManager.default
+        let persistenceRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("HarborNetworkKillSwitchTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: persistenceRoot) }
+
+        let catalog = makeVPNCatalog(
+            resolvedBinding: ResolvedNetworkBinding(
+                interfaceName: "utun6",
+                ipv4Address: "10.2.0.2"
+            )
+        )
+        let settings = AppSettingsStore(
+            userDefaults: userDefaults,
+            networkBindingCatalog: catalog
+        )
+        let monitor = NetworkBindingMonitor(catalog: catalog, debounceInterval: 0)
+        let startLog = EventLog()
+        let center = DownloadCenter(
+            settings: settings,
+            persistence: DownloadPersistence(directoryURL: persistenceRoot),
+            networkBindingMonitor: monitor,
+            torrentService: Aria2TorrentService(daemonStartupOperation: { _ in }),
+            torrentPauseOperation: { _, _ in },
+            torrentStartOperation: { _, _, sourceURL, _, _ in
+                startLog.record(sourceURL.absoluteString)
+                return "resumed-gid"
+            }
+        )
+        await center.initializeIfNeeded()
+
+        let activeTorrent = DownloadItem(
+            sourceURL: try XCTUnwrap(
+                URL(string: "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567")
+            ),
+            sourceKind: .magnetLink,
+            backend: .aria2,
+            preferredFilename: nil,
+            destinationFolderPath: persistenceRoot.path,
+            status: .downloading
+        )
+        let manuallyPausedTorrent = DownloadItem(
+            sourceURL: try XCTUnwrap(
+                URL(string: "magnet:?xt=urn:btih:89abcdef0123456789abcdef0123456789abcdef")
+            ),
+            sourceKind: .magnetLink,
+            backend: .aria2,
+            preferredFilename: nil,
+            destinationFolderPath: persistenceRoot.path,
+            status: .paused
+        )
+        // Neither item carries an engine identifier, so the periodic torrent
+        // status poll stays out of this test.
+        center.downloads = [activeTorrent, manuallyPausedTorrent]
+
+        settings.networkBindingSelection = vpnSelection
+        XCTAssertEqual(
+            settings.networkBindingStatus,
+            .bound(
+                displayName: "ProtonVPN",
+                binding: ResolvedNetworkBinding(
+                    interfaceName: "utun6",
+                    ipv4Address: "10.2.0.2"
+                )
+            )
+        )
+        XCTAssertEqual(activeTorrent.status, .downloading)
+
+        catalog.resolvedBinding = nil
+        monitor.refreshStatus()
+
+        XCTAssertEqual(settings.networkBindingStatus, .unavailable(displayName: "ProtonVPN"))
+        XCTAssertEqual(activeTorrent.status, .paused)
+        XCTAssertEqual(manuallyPausedTorrent.status, .paused)
+
+        // The VPN reconnects on a different interface, which is exactly why the
+        // engine has to be rebound rather than merely restarted.
+        catalog.resolvedBinding = ResolvedNetworkBinding(
+            interfaceName: "utun7",
+            ipv4Address: "10.2.0.3"
+        )
+        monitor.refreshStatus()
+
+        for _ in 0 ..< 200 where startLog.recorded.isEmpty {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(
+            startLog.recorded,
+            [activeTorrent.sourceURL.absoluteString],
+            "Only the torrent Harbor suspended may be restarted"
+        )
+        XCTAssertEqual(
+            manuallyPausedTorrent.status,
+            .paused,
+            "A manually paused torrent must not be resumed by the network coming back"
+        )
+
+        await center.shutdownForTermination()
+    }
+}

--- a/HarborTests/NetworkBindingTests.swift
+++ b/HarborTests/NetworkBindingTests.swift
@@ -169,6 +169,30 @@ final class NetworkBindingTests: XCTestCase {
         )
     }
 
+    func testVPNServicesAreDistinguishableFromOrdinaryConnections() {
+        XCTAssertEqual(
+            SystemNetworkBindingCatalog.symbolName(forInterfaceType: "VPN"),
+            "lock.shield"
+        )
+        XCTAssertEqual(
+            SystemNetworkBindingCatalog.symbolName(forInterfaceType: "IPSec"),
+            "lock.shield"
+        )
+        XCTAssertEqual(
+            SystemNetworkBindingCatalog.symbolName(forInterfaceType: "IEEE80211"),
+            "wifi"
+        )
+        XCTAssertEqual(
+            SystemNetworkBindingCatalog.symbolName(forInterfaceType: "Ethernet"),
+            "cable.connector"
+        )
+        // A service macOS cannot classify still gets a usable icon.
+        XCTAssertEqual(
+            SystemNetworkBindingCatalog.symbolName(forInterfaceType: nil),
+            "network"
+        )
+    }
+
     func testOnlyUsableInterfacesAreOffered() {
         for name in ["en0", "en5", "utun4", "bridge0", "ppp0"] {
             XCTAssertTrue(

--- a/HarborTests/NetworkBindingTests.swift
+++ b/HarborTests/NetworkBindingTests.swift
@@ -72,6 +72,18 @@ private func makeVPNCatalog(
     )
 }
 
+private func makeInterfaceTarget(
+    name: String,
+    medium: NetworkBindingMedium
+) -> NetworkBindingTarget {
+    NetworkBindingTarget(
+        selection: .interface(name: name),
+        displayName: name,
+        kind: .interface,
+        medium: medium
+    )
+}
+
 @MainActor
 final class NetworkBindingTests: XCTestCase {
     func testSelectionRoundTripsThroughStorageValue() {
@@ -170,27 +182,48 @@ final class NetworkBindingTests: XCTestCase {
     }
 
     func testVPNServicesAreDistinguishableFromOrdinaryConnections() {
+        XCTAssertEqual(SystemNetworkBindingCatalog.medium(forInterfaceType: "VPN"), .vpn)
+        XCTAssertEqual(SystemNetworkBindingCatalog.medium(forInterfaceType: "IPSec"), .vpn)
         XCTAssertEqual(
-            SystemNetworkBindingCatalog.symbolName(forInterfaceType: "VPN"),
-            "lock.shield"
+            SystemNetworkBindingCatalog.medium(forInterfaceType: "IEEE80211"),
+            .wireless
         )
         XCTAssertEqual(
-            SystemNetworkBindingCatalog.symbolName(forInterfaceType: "IPSec"),
-            "lock.shield"
+            SystemNetworkBindingCatalog.medium(forInterfaceType: "Ethernet"),
+            .wired
         )
-        XCTAssertEqual(
-            SystemNetworkBindingCatalog.symbolName(forInterfaceType: "IEEE80211"),
-            "wifi"
-        )
-        XCTAssertEqual(
-            SystemNetworkBindingCatalog.symbolName(forInterfaceType: "Ethernet"),
-            "cable.connector"
-        )
+        XCTAssertEqual(SystemNetworkBindingCatalog.medium(forInterfaceType: "Bridge"), .wired)
         // A service macOS cannot classify still gets a usable icon.
+        XCTAssertEqual(SystemNetworkBindingCatalog.medium(forInterfaceType: nil), .other)
+        XCTAssertEqual(NetworkBindingMedium.other.symbolName, "network")
+        XCTAssertEqual(NetworkBindingMedium.vpn.symbolName, "lock.shield")
+    }
+
+    /// A tunnel is the point of this setting, so it has to lead the list even
+    /// though its name sorts last.
+    func testTargetsAreGroupedByMediumBeforeName() {
+        let targets = NetworkBindingTarget.sortedByMedium([
+            makeInterfaceTarget(name: "en10", medium: .wired),
+            makeInterfaceTarget(name: "en2", medium: .wired),
+            makeInterfaceTarget(name: "utun4", medium: .vpn),
+            makeInterfaceTarget(name: "bridge0", medium: .other),
+            makeInterfaceTarget(name: "en0", medium: .wireless),
+            makeInterfaceTarget(name: "utun0", medium: .vpn)
+        ])
+
         XCTAssertEqual(
-            SystemNetworkBindingCatalog.symbolName(forInterfaceType: nil),
-            "network"
+            targets.map(\.displayName),
+            ["utun0", "utun4", "en0", "en2", "en10", "bridge0"]
         )
+    }
+
+    /// macOS has no SCNetworkInterface for a tunnel that is not up, so the name
+    /// carries the classification on its own.
+    func testTunnelInterfacesAreClassifiedByName() {
+        XCTAssertEqual(SystemNetworkBindingCatalog.medium(forInterfaceName: "utun4"), .vpn)
+        XCTAssertEqual(SystemNetworkBindingCatalog.medium(forInterfaceName: "ipsec0"), .vpn)
+        XCTAssertEqual(SystemNetworkBindingCatalog.medium(forInterfaceName: "ppp0"), .vpn)
+        XCTAssertEqual(SystemNetworkBindingCatalog.medium(forInterfaceName: "en0"), .other)
     }
 
     func testOnlyUsableInterfacesAreOffered() {

--- a/HarborUITests/HarborSettingsUITests.swift
+++ b/HarborUITests/HarborSettingsUITests.swift
@@ -50,6 +50,6 @@ final class HarborSettingsUITests: HarborUITestCase {
 
         let interfacePicker = app.popUpButtons["settings.torrents.networkInterface"].firstMatch
         XCTAssertTrue(interfacePicker.waitForExistence(timeout: 10))
-        XCTAssertEqual(String(describing: interfacePicker.value), "Any Interface")
+        XCTAssertEqual(String(describing: interfacePicker.value), "Automatic")
     }
 }

--- a/HarborUITests/HarborSettingsUITests.swift
+++ b/HarborUITests/HarborSettingsUITests.swift
@@ -39,4 +39,17 @@ final class HarborSettingsUITests: HarborUITestCase {
         XCTAssertTrue(app.staticTexts["yt-dlp"].exists)
         XCTAssertTrue(app.staticTexts["Deno"].exists)
     }
+
+    func testTorrentsTabOffersNetworkInterfaceBinding() {
+        launchHarbor()
+        app.typeKey(",", modifierFlags: [.command])
+
+        let torrentsTab = app.buttons["Torrents"].firstMatch
+        XCTAssertTrue(torrentsTab.waitForExistence(timeout: 10))
+        torrentsTab.click()
+
+        let interfacePicker = app.popUpButtons["settings.torrents.networkInterface"].firstMatch
+        XCTAssertTrue(interfacePicker.waitForExistence(timeout: 10))
+        XCTAssertEqual(String(describing: interfacePicker.value), "Any Interface")
+    }
 }


### PR DESCRIPTION
## What changed

Harbor's aria2 daemon opened its sockets on whatever route macOS preferred. When a VPN dropped, torrent traffic silently continued over the normal connection and exposed the real address.

Settings › Torrents now offers a network interface to bind torrents to: `Automatic`, the configured network services (Wi-Fi, Ethernet, ProtonVPN and friends), or a raw BSD interface. Both groups are ordered by what they carry traffic over — tunnel, wireless, wired, then whatever macOS cannot classify — and each entry carries a matching icon, so a VPN heads the list instead of hiding among adapters that cannot serve the purpose of this setting.

While the selected interface is gone, Harbor pauses every torrent, stops the engine, and refuses to start it, then resumes exactly the torrents it suspended once the interface returns. A manually paused torrent stays paused.

## Relates to #72

| Acceptance criterion | Status |
| --- | --- |
| Settings provides `Automatic` and available network-interface choices | done |
| New direct downloads use the selected interface | **not included**, see below |
| New torrent downloads pass the selected interface or local address to aria2 | done, via `--interface` |
| Harbor does not silently fall back to another interface | done, the engine refuses to start |
| Harbor pauses or fails the affected transfer with a clear message | done |
| Existing downloads keep predictable behavior when the setting changes | done |
| The UI identifies VPN and tunnel interfaces | done |

Direct downloads are left out deliberately. `URLSession` and `URLSessionConfiguration` expose no interface binding on macOS, and `kCFStreamPropertyBoundInterfaceIdentifier` does not exist there. Only `nw_parameters_require_interface` can bind a socket, which would mean rebuilding `DownloadCoordinator` on `NWConnection`, resume data and browser handoff included. Pausing direct downloads without binding them would look like protection while still leaking, so the settings text says plainly that the binding covers torrents only.

## Notes on the implementation

Four things turned out to matter more than expected:

- **A VPN cannot be resolved through the dynamic store.** ProtonVPN publishes its address under a per-session identifier with no link back to the configured service: the configured service was `2EB5D77A-…` while the address landed under an unrelated `E1D5F77F-…` that changes on every connection. `SCNetworkConnectionCopyExtendedStatus` reports interface and address for the stable service identifier, so the catalog falls back to it. Wired and wireless services keep using the dynamic store, which answers for them directly.
- **The binding has to be applied before session recovery.** `initializeIfNeeded` reaches the engine while restoring the saved session, so the configuration is applied and awaited first. Otherwise a restored torrent transfers briefly over whatever route the system prefers. There is a test for the ordering.
- **A BSD name does not say what it is.** `en0` is Wi-Fi and `en5` a USB Ethernet adapter; only `SCNetworkInterfaceCopyAll` tells them apart, and that is what the picker sorts and labels by. Tunnels are the exception: they have no `SCNetworkInterface` while they are down, so a `utunN` is classified by its name.
- **A missing interface is not a failure.** `aria2` exits immediately when `--interface` names a missing interface, so Harbor checks availability itself and classifies the condition as transient. Suspended torrents keep their status instead of being marked failed.

`--interface` is fixed at launch and its resolved address is cached, so a changed binding saves the session and restarts the daemon.

## How this was tested

148 unit tests pass, 14 of them new. Beyond that, verified against a real ProtonVPN connection on macOS 27.0 (26A5421a):

| Check | Result |
| --- | --- |
| `--interface=en0` | outgoing socket bound to that adapter's address rather than the default route |
| RPC reachable while bound | `127.0.0.1` still answers, `--interface` does not move the listener |
| Missing interface | `aria2` refuses to start: `Failed to find given interface …, cause: not available` |
| ProtonVPN resolution | service resolves to `utun4` / `10.2.0.2` |
| Live daemon | `--interface=utun4`; DHT, peer listener and tracker connections all on the VPN address, nothing on the LAN address |
| Disconnect | torrent paused and engine stopped within 2 s |
| Reconnect | engine rebound and the suspended torrent resumed within 2 s |

The offline UI test plan does not run in my environment; the existing settings UI test fails identically on a clean checkout of `main`, so I could not confirm the one I added.

## Screenshots

<img width="610" height="185" alt="image" src="https://github.com/user-attachments/assets/cd7c4ce0-c5e8-461b-9097-7e40fde8a11a" />
<img width="711" height="613" alt="image" src="https://github.com/user-attachments/assets/b2c3a097-1548-43cc-ac53-e88d41f149f1" />

The picker, grouped by connection type:

_(attaching)_


## AI assistance

Written with Claude Code (Opus 5). I used it to explore the aria2 and SystemConfiguration behaviour, write the implementation and tests, and drive the live VPN verification above. I reviewed the result and am responsible for it.


